### PR TITLE
Implement DRBD metrics for disk-state

### DIFF
--- a/drb_metrics.go
+++ b/drb_metrics.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// return drbd status in byte raw json
+func getDrbdInfo() []byte {
+	// get ringStatus
+	log.Println("[INFO]: Reading drbd status with drbdsetup status ...")
+	drbdStatusRaw, _ := exec.Command("/usr/sbin/drbdsetup", "status" "--json").Output()
+	return drbdStatusRaw
+}

--- a/drbd_metrics.go
+++ b/drbd_metrics.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"log"
 	"os/exec"
 )
@@ -21,4 +22,13 @@ func getDrbdInfo() []byte {
 	log.Println("[INFO]: Reading drbd status with drbdsetup status ...")
 	drbdStatusRaw, _ := exec.Command("/sbin/drbdsetup", "status", "--json").Output()
 	return drbdStatusRaw
+}
+
+func parseDrbdStatus(statusRaw []byte) ([]drbdStatus, error) {
+	var drbdDevs []drbdStatus
+	err := json.Unmarshal(statusRaw, &drbdDevs)
+	if err != nil {
+		return drbdDevs, err
+	}
+	return drbdDevs, nil
 }

--- a/drbd_metrics.go
+++ b/drbd_metrics.go
@@ -10,7 +10,8 @@ type drbdStatus struct {
 	Name    string `json:"name"`
 	Role    string `json:"role"`
 	Devices []struct {
-		Volume int `json:"volume"`
+		Volume    int    `json:"volume"`
+		DiskState string `json:"disk-state"`
 	} `json:"devices"`
 }
 

--- a/drbd_metrics.go
+++ b/drbd_metrics.go
@@ -1,18 +1,14 @@
 package main
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
+	"log"
 	"os/exec"
-	"regexp"
-	"strings"
 )
 
 // return drbd status in byte raw json
 func getDrbdInfo() []byte {
 	// get ringStatus
 	log.Println("[INFO]: Reading drbd status with drbdsetup status ...")
-	drbdStatusRaw, _ := exec.Command("/usr/sbin/drbdsetup", "status" "--json").Output()
+	drbdStatusRaw, _ := exec.Command("/usr/sbin/drbdsetup", "status", "--json").Output()
 	return drbdStatusRaw
 }

--- a/drbd_metrics.go
+++ b/drbd_metrics.go
@@ -9,6 +9,6 @@ import (
 func getDrbdInfo() []byte {
 	// get ringStatus
 	log.Println("[INFO]: Reading drbd status with drbdsetup status ...")
-	drbdStatusRaw, _ := exec.Command("/usr/sbin/drbdsetup", "status", "--json").Output()
+	drbdStatusRaw, _ := exec.Command("/sbin/drbdsetup", "status", "--json").Output()
 	return drbdStatusRaw
 }

--- a/drbd_metrics.go
+++ b/drbd_metrics.go
@@ -5,6 +5,15 @@ import (
 	"os/exec"
 )
 
+// drbdStatus is for parsing relevant data we want to convert to metrics
+type drbdStatus struct {
+	Name    string `json:"name"`
+	Role    string `json:"role"`
+	Devices []struct {
+		Volume int `json:"volume"`
+	} `json:"devices"`
+}
+
 // return drbd status in byte raw json
 func getDrbdInfo() []byte {
 	// get ringStatus

--- a/drbd_metrics.go
+++ b/drbd_metrics.go
@@ -17,11 +17,11 @@ type drbdStatus struct {
 }
 
 // return drbd status in byte raw json
-func getDrbdInfo() []byte {
+func getDrbdInfo() ([]byte, error) {
 	// get ringStatus
 	log.Println("[INFO]: Reading drbd status with drbdsetup status ...")
-	drbdStatusRaw, _ := exec.Command("/sbin/drbdsetup", "status", "--json").Output()
-	return drbdStatusRaw
+	drbdStatusRaw, err := exec.Command("/sbin/drbdsetup", "status", "--json").Output()
+	return drbdStatusRaw, err
 }
 
 func parseDrbdStatus(statusRaw []byte) ([]drbdStatus, error) {

--- a/drbd_metrics_test.go
+++ b/drbd_metrics_test.go
@@ -112,161 +112,29 @@ func TestDrbdParsing(t *testing.T) {
 				  "percent-in-sync": 100.00
 				} ]
 			} ]
-		}
-		,
-		{
-		  "name": "vg1",
-		  "node-id": 2,
-		  "role": "Secondary",
-		  "suspended": false,
-		  "write-ordering": "flush",
-		  "devices": [
-			{
-			  "volume": 0,
-			  "minor": 6,
-			  "disk-state": "UpToDate",
-			  "client": false,
-			  "quorum": true,
-			  "size": 409548,
-			  "read": 0,
-			  "written": 548525,
-			  "al-writes": 4,
-			  "bm-writes": 0,
-			  "upper-pending": 0,
-			  "lower-pending": 0
-			} ],
-		  "connections": [
-			{
-			  "peer-node-id": 1,
-			  "name": "SLE15-sp1-gm-drbd1145296-node1",
-			  "connection-state": "Connected", 
-			  "congested": false,
-			  "peer-role": "Primary",
-			  "ap-in-flight": 0,
-			  "rs-in-flight": 0,
-			  "peer_devices": [
-				{
-				  "volume": 0,
-				  "replication-state": "Established",
-				  "peer-disk-state": "UpToDate",
-				  "peer-client": false,
-				  "resync-suspended": "no",
-				  "received": 548525,
-				  "sent": 0,
-				  "out-of-sync": 0,
-				  "pending": 0,
-				  "unacked": 0,
-				  "has-sync-details": false,
-				  "has-online-verify-details": false,
-				  "percent-in-sync": 100.00
-				} ]
-			} ]
-		}
-		,
-		{
-		  "name": "vg2",
-		  "node-id": 2,
-		  "role": "Secondary",
-		  "suspended": false,
-		  "write-ordering": "flush",
-		  "devices": [
-			{
-			  "volume": 0,
-			  "minor": 7,
-			  "disk-state": "UpToDate",
-			  "client": false,
-			  "quorum": true,
-			  "size": 307152,
-			  "read": 0,
-			  "written": 548541,
-			  "al-writes": 4,
-			  "bm-writes": 0,
-			  "upper-pending": 0,
-			  "lower-pending": 0
-			} ],
-		  "connections": [
-			{
-			  "peer-node-id": 1,
-			  "name": "SLE15-sp1-gm-drbd1145296-node1",
-			  "connection-state": "Connected", 
-			  "congested": false,
-			  "peer-role": "Primary",
-			  "ap-in-flight": 0,
-			  "rs-in-flight": 0,
-			  "peer_devices": [
-				{
-				  "volume": 0,
-				  "replication-state": "Established",
-				  "peer-disk-state": "UpToDate",
-				  "peer-client": false,
-				  "resync-suspended": "no",
-				  "received": 548541,
-				  "sent": 0,
-				  "out-of-sync": 0,
-				  "pending": 0,
-				  "unacked": 0,
-				  "has-sync-details": false,
-				  "has-online-verify-details": false,
-				  "percent-in-sync": 100.00
-				} ]
-			} ]
-		}
-		,
-		{
-		  "name": "vg3",
-		  "node-id": 2,
-		  "role": "Secondary",
-		  "suspended": false,
-		  "write-ordering": "flush",
-		  "devices": [
-			{
-			  "volume": 0,
-			  "minor": 8,
-			  "disk-state": "UpToDate",
-			  "client": false,
-			  "quorum": true,
-			  "size": 204756,
-			  "read": 0,
-			  "written": 548576,
-			  "al-writes": 3,
-			  "bm-writes": 0,
-			  "upper-pending": 0,
-			  "lower-pending": 0
-			} ],
-		  "connections": [
-			{
-			  "peer-node-id": 1,
-			  "name": "SLE15-sp1-gm-drbd1145296-node1",
-			  "connection-state": "Connected", 
-			  "congested": false,
-			  "peer-role": "Primary",
-			  "ap-in-flight": 0,
-			  "rs-in-flight": 0,
-			  "peer_devices": [
-				{
-				  "volume": 0,
-				  "replication-state": "Established",
-				  "peer-disk-state": "UpToDate",
-				  "peer-client": false,
-				  "resync-suspended": "no",
-				  "received": 548576,
-				  "sent": 0,
-				  "out-of-sync": 0,
-				  "pending": 0,
-				  "unacked": 0,
-				  "has-sync-details": false,
-				  "has-online-verify-details": false,
-				  "percent-in-sync": 100.00
-				} ]
-			} ]
-		}
-		]`)
+		}]`)
 
 	var drbdDevs []drbdStatus
 	err := json.Unmarshal(drbdDataRaw, &drbdDevs)
 	if err != nil {
 		log.Fatalln("[ERROR]:", err)
 	}
-	log.Println(drbdDevs[0].Devices[0].Volume)
+	// test attributes
+	if "1-single-0" != drbdDevs[0].Name {
+		t.Errorf("name doesn't correspond! fail got %s", drbdDevs[0].Name)
+	}
+
+	if "Secondary" != drbdDevs[0].Role {
+		t.Errorf("role doesn't correspond! fail got %s", drbdDevs[0].Role)
+	}
+
+	if "UpToDate" != drbdDevs[0].Devices[0].DiskState {
+		t.Errorf("disk-states doesn't correspond! fail got %s", drbdDevs[0].Devices[0].DiskState)
+
+	}
+
+	if 0 != drbdDevs[0].Devices[0].Volume {
+		t.Errorf("volumes should be 0")
+	}
 
 }

--- a/drbd_metrics_test.go
+++ b/drbd_metrics_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"testing"
@@ -114,8 +113,7 @@ func TestDrbdParsing(t *testing.T) {
 			} ]
 		}]`)
 
-	var drbdDevs []drbdStatus
-	err := json.Unmarshal(drbdDataRaw, &drbdDevs)
+	drbdDevs, err := parseDrbdStatus(drbdDataRaw)
 	if err != nil {
 		log.Fatalln("[ERROR]:", err)
 	}

--- a/drbd_metrics_test.go
+++ b/drbd_metrics_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
 	"testing"
 )
 
@@ -10,4 +12,261 @@ import (
 func TestDrbdStatusFuncMinimalError(t *testing.T) {
 	fmt.Println("=== Testing DRBD : testing function to get infos")
 	getDrbdInfo()
+}
+
+func TestDrbdParsing(t *testing.T) {
+	var drbdDataRaw = []byte(` [
+		{
+		  "name": "1-single-0",
+		  "node-id": 2,
+		  "role": "Secondary",
+		  "suspended": false,
+		  "write-ordering": "flush",
+		  "devices": [
+			{
+			  "volume": 0,
+			  "minor": 2,
+			  "disk-state": "UpToDate",
+			  "client": false,
+			  "quorum": true,
+			  "size": 409600,
+			  "read": 0,
+			  "written": 548525,
+			  "al-writes": 4,
+			  "bm-writes": 0,
+			  "upper-pending": 0,
+			  "lower-pending": 0
+			} ],
+		  "connections": [
+			{
+			  "peer-node-id": 1,
+			  "name": "SLE15-sp1-gm-drbd1145296-node1",
+			  "connection-state": "Connected", 
+			  "congested": false,
+			  "peer-role": "Primary",
+			  "ap-in-flight": 0,
+			  "rs-in-flight": 0,
+			  "peer_devices": [
+				{
+				  "volume": 0,
+				  "replication-state": "Established",
+				  "peer-disk-state": "UpToDate",
+				  "peer-client": false,
+				  "resync-suspended": "no",
+				  "received": 548525,
+				  "sent": 0,
+				  "out-of-sync": 0,
+				  "pending": 0,
+				  "unacked": 0,
+				  "has-sync-details": false,
+				  "has-online-verify-details": false,
+				  "percent-in-sync": 100.00
+				} ]
+			} ]
+		}
+		,
+		{
+		  "name": "1-single-1",
+		  "node-id": 2,
+		  "role": "Secondary",
+		  "suspended": false,
+		  "write-ordering": "flush",
+		  "devices": [
+			{
+			  "volume": 0,
+			  "minor": 3,
+			  "disk-state": "UpToDate",
+			  "client": false,
+			  "quorum": true,
+			  "size": 10200,
+			  "read": 0,
+			  "written": 546005,
+			  "al-writes": 1,
+			  "bm-writes": 0,
+			  "upper-pending": 0,
+			  "lower-pending": 0
+			} ],
+		  "connections": [
+			{
+			  "peer-node-id": 1,
+			  "name": "SLE15-sp1-gm-drbd1145296-node1",
+			  "connection-state": "Connected", 
+			  "congested": false,
+			  "peer-role": "Primary",
+			  "ap-in-flight": 0,
+			  "rs-in-flight": 0,
+			  "peer_devices": [
+				{
+				  "volume": 0,
+				  "replication-state": "Established",
+				  "peer-disk-state": "UpToDate",
+				  "peer-client": false,
+				  "resync-suspended": "no",
+				  "received": 546005,
+				  "sent": 0,
+				  "out-of-sync": 0,
+				  "pending": 0,
+				  "unacked": 0,
+				  "has-sync-details": false,
+				  "has-online-verify-details": false,
+				  "percent-in-sync": 100.00
+				} ]
+			} ]
+		}
+		,
+		{
+		  "name": "vg1",
+		  "node-id": 2,
+		  "role": "Secondary",
+		  "suspended": false,
+		  "write-ordering": "flush",
+		  "devices": [
+			{
+			  "volume": 0,
+			  "minor": 6,
+			  "disk-state": "UpToDate",
+			  "client": false,
+			  "quorum": true,
+			  "size": 409548,
+			  "read": 0,
+			  "written": 548525,
+			  "al-writes": 4,
+			  "bm-writes": 0,
+			  "upper-pending": 0,
+			  "lower-pending": 0
+			} ],
+		  "connections": [
+			{
+			  "peer-node-id": 1,
+			  "name": "SLE15-sp1-gm-drbd1145296-node1",
+			  "connection-state": "Connected", 
+			  "congested": false,
+			  "peer-role": "Primary",
+			  "ap-in-flight": 0,
+			  "rs-in-flight": 0,
+			  "peer_devices": [
+				{
+				  "volume": 0,
+				  "replication-state": "Established",
+				  "peer-disk-state": "UpToDate",
+				  "peer-client": false,
+				  "resync-suspended": "no",
+				  "received": 548525,
+				  "sent": 0,
+				  "out-of-sync": 0,
+				  "pending": 0,
+				  "unacked": 0,
+				  "has-sync-details": false,
+				  "has-online-verify-details": false,
+				  "percent-in-sync": 100.00
+				} ]
+			} ]
+		}
+		,
+		{
+		  "name": "vg2",
+		  "node-id": 2,
+		  "role": "Secondary",
+		  "suspended": false,
+		  "write-ordering": "flush",
+		  "devices": [
+			{
+			  "volume": 0,
+			  "minor": 7,
+			  "disk-state": "UpToDate",
+			  "client": false,
+			  "quorum": true,
+			  "size": 307152,
+			  "read": 0,
+			  "written": 548541,
+			  "al-writes": 4,
+			  "bm-writes": 0,
+			  "upper-pending": 0,
+			  "lower-pending": 0
+			} ],
+		  "connections": [
+			{
+			  "peer-node-id": 1,
+			  "name": "SLE15-sp1-gm-drbd1145296-node1",
+			  "connection-state": "Connected", 
+			  "congested": false,
+			  "peer-role": "Primary",
+			  "ap-in-flight": 0,
+			  "rs-in-flight": 0,
+			  "peer_devices": [
+				{
+				  "volume": 0,
+				  "replication-state": "Established",
+				  "peer-disk-state": "UpToDate",
+				  "peer-client": false,
+				  "resync-suspended": "no",
+				  "received": 548541,
+				  "sent": 0,
+				  "out-of-sync": 0,
+				  "pending": 0,
+				  "unacked": 0,
+				  "has-sync-details": false,
+				  "has-online-verify-details": false,
+				  "percent-in-sync": 100.00
+				} ]
+			} ]
+		}
+		,
+		{
+		  "name": "vg3",
+		  "node-id": 2,
+		  "role": "Secondary",
+		  "suspended": false,
+		  "write-ordering": "flush",
+		  "devices": [
+			{
+			  "volume": 0,
+			  "minor": 8,
+			  "disk-state": "UpToDate",
+			  "client": false,
+			  "quorum": true,
+			  "size": 204756,
+			  "read": 0,
+			  "written": 548576,
+			  "al-writes": 3,
+			  "bm-writes": 0,
+			  "upper-pending": 0,
+			  "lower-pending": 0
+			} ],
+		  "connections": [
+			{
+			  "peer-node-id": 1,
+			  "name": "SLE15-sp1-gm-drbd1145296-node1",
+			  "connection-state": "Connected", 
+			  "congested": false,
+			  "peer-role": "Primary",
+			  "ap-in-flight": 0,
+			  "rs-in-flight": 0,
+			  "peer_devices": [
+				{
+				  "volume": 0,
+				  "replication-state": "Established",
+				  "peer-disk-state": "UpToDate",
+				  "peer-client": false,
+				  "resync-suspended": "no",
+				  "received": 548576,
+				  "sent": 0,
+				  "out-of-sync": 0,
+				  "pending": 0,
+				  "unacked": 0,
+				  "has-sync-details": false,
+				  "has-online-verify-details": false,
+				  "percent-in-sync": 100.00
+				} ]
+			} ]
+		}
+		]`)
+
+	var drbdDevs []drbdStatus
+	err := json.Unmarshal(drbdDataRaw, &drbdDevs)
+	if err != nil {
+		log.Fatalln("[ERROR]:", err)
+	}
+	log.Println(drbdDevs[0].Devices[0].Volume)
+
 }

--- a/drbd_metrics_test.go
+++ b/drbd_metrics_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+// this test verify that we return something when call the function.
+// we can't really test it since we need the binary
+func TestDrbdStatusFuncMinimalError(t *testing.T) {
+	fmt.Println("=== Testing DRBD : testing function to get infos")
+	getDrbdInfo()
+}

--- a/ha_cluster_exporter.go
+++ b/ha_cluster_exporter.go
@@ -184,12 +184,17 @@ func main() {
 	// set DRBD metrics
 	go func() {
 		for {
+			// retrieve info via binary
 			drbdStatusJSONRaw := getDrbdInfo()
-			log.Printf("DRBD_DEBUG: %s", drbdStatusJSONRaw)
-			// todo parse json, drbdStatus will contain all data parsed from json
-			//drbdStatus := parseDRBD(drbdStatusJSONRaw)
-			// set metrics accordingly
-
+			// populate structs and parse relevant info
+			drbdDev, err := parseDrbdStatus(drbdStatusJSONRaw)
+			if err != nil {
+				log.Println(err)
+				time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
+				continue
+			}
+			// set drbd metric
+			log.Println(drbdDev)
 			time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
 		}
 	}()

--- a/ha_cluster_exporter.go
+++ b/ha_cluster_exporter.go
@@ -185,7 +185,7 @@ func main() {
 	go func() {
 		for {
 			drbdStatusJSONRaw := getDrbdInfo()
-			log.Println(drbdStatusJSONRaw)
+			log.Printf("DRBD_DEBUG: %s", drbdStatusJSONRaw)
 			// todo parse json, drbdStatus will contain all data parsed from json
 			//drbdStatus := parseDRBD(drbdStatusJSONRaw)
 			// set metrics accordingly
@@ -201,13 +201,15 @@ func main() {
 			sbdConfiguration, err := readSdbFile()
 			if err != nil {
 				log.Println(err)
+				time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
 				continue
 			}
 			// retrieve a list of sbd devices
 			sbdDevices, err2 := getSbdDevices(sbdConfiguration)
 			// mostly, the sbd_device were not set in conf file for returning an error
 			if err2 != nil {
-				log.Println(err)
+				log.Println(err2)
+				time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
 				continue
 			}
 			// set and return a map of sbd devices with true healthy, false not
@@ -215,6 +217,7 @@ func main() {
 
 			if len(sbdStatus) == 0 {
 				log.Println("[WARN]: Could not retrieve any sbd device")
+				time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
 				continue
 			}
 
@@ -239,6 +242,7 @@ func main() {
 			if err != nil {
 				log.Println("[ERROR]: could not execute command: usr/sbin/corosync-cfgtool -s")
 				log.Println(err)
+				time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
 				continue
 			}
 			corosyncRingErrorsTotal.Set(float64(ringErrorsTotal))
@@ -253,6 +257,7 @@ func main() {
 
 			if len(voteQuorumInfo) == 0 {
 				log.Println("[ERROR]: Could not retrieve any quorum information, map is empty")
+				time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
 				continue
 			}
 
@@ -284,6 +289,7 @@ func main() {
 			if err != nil {
 				log.Println("[ERROR]: fail to 	 reset metrics for cluster crm_mon component")
 				log.Println(err)
+				time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
 				continue
 			}
 			// get cluster status xml
@@ -292,6 +298,7 @@ func main() {
 			if err != nil {
 				log.Println("[ERROR]: crm_mon command execution failed. Did you have crm_mon installed ?")
 				log.Println(err)
+				time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
 				continue
 			}
 
@@ -301,6 +308,7 @@ func main() {
 			if err != nil {
 				log.Println("[ERROR]: could not read cluster XML configuration")
 				log.Println(err)
+				time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
 				continue
 			}
 

--- a/ha_cluster_exporter.go
+++ b/ha_cluster_exporter.go
@@ -184,9 +184,12 @@ func main() {
 	// set DRBD metrics
 	go func() {
 		for {
-			drbdStatusJsonRaw := getDrbdInfo()
-			// TODO: parse json
-			log.Println(drbdStatusJsonRaw)
+			drbdStatusJSONRaw := getDrbdInfo()
+			log.Println(drbdStatusJSONRaw)
+			// todo parse json, drbdStatus will contain all data parsed from json
+			//drbdStatus := parseDRBD(drbdStatusJSONRaw)
+			// set metrics accordingly
+
 			time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
 		}
 	}()
@@ -201,7 +204,12 @@ func main() {
 				continue
 			}
 			// retrieve a list of sbd devices
-			sbdDevices := getSbdDevices(sbdConfiguration)
+			sbdDevices, err2 := getSbdDevices(sbdConfiguration)
+			// mostly, the sbd_device were not set in conf file for returning an error
+			if err2 != nil {
+				log.Println(err)
+				continue
+			}
 			// set and return a map of sbd devices with true healthy, false not
 			sbdStatus := setSbdDeviceHealth(sbdDevices)
 

--- a/ha_cluster_exporter.go
+++ b/ha_cluster_exporter.go
@@ -181,6 +181,15 @@ func main() {
 
 	// for each different metrics, handle it in differents gorutines, and use same timeout.
 
+	// set DRBD metrics
+	go func() {
+		for {
+			drbdStatusJsonRaw := getDrbdInfo()
+			// TODO: parse json
+			log.Println(drbdStatusJsonRaw)
+			time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
+		}
+	}()
 	// set SBD device metrics
 	go func() {
 		for {

--- a/ha_cluster_exporter.go
+++ b/ha_cluster_exporter.go
@@ -14,61 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// this types are for reading pacemaker configuration xml when running crm_mon command
-// and lookup the corrispective value
-type crmMon struct {
-	Version string  `xml:"version,attr"`
-	Summary summary `xml:"summary"`
-	Nodes   nodes   `xml:"nodes"`
-}
-
-type summary struct {
-	Nodes struct {
-		Number int `xml:"number,attr"`
-	} `xml:"nodes_configured"`
-	Resources resourcesConfigured `xml:"resources_configured"`
-}
-
-type resourcesConfigured struct {
-	Number   int `xml:"number,attr"`
-	Disabled int `xml:"disabled,attr"`
-	Blocked  int `xml:"blocked,attr"`
-}
-
-type nodes struct {
-	Node []node `xml:"node"`
-}
-
-type node struct {
-	Name             string     `xml:"name,attr"`
-	ID               string     `xml:"id,attr"`
-	Online           bool       `xml:"online,attr"`
-	Standby          bool       `xml:"standby,attr"`
-	StandbyOnFail    bool       `xml:"standby_onfail,attr"`
-	Maintenance      bool       `xml:"maintenance,attr"`
-	Pending          bool       `xml:"pending,attr"`
-	Unclean          bool       `xml:"unclean,attr"`
-	Shutdown         bool       `xml:"shutdown,attr"`
-	ExpectedUp       bool       `xml:"expected_up,attr"`
-	DC               bool       `xml:"is_dc,attr"`
-	ResourcesRunning int        `xml:"resources_running,attr"`
-	Type             string     `xml:"type,attr"`
-	Resources        []resource `xml:"resource"`
-}
-
-type resource struct {
-	ID             string `xml:"id,attr"`
-	Agent          string `xml:"resource_agent,attr"`
-	Role           string `xml:"role,attr"`
-	Active         bool   `xml:"active,attr"`
-	Orphaned       bool   `xml:"orphaned,attr"`
-	Blocked        bool   `xml:"blocked,attr"`
-	Managed        bool   `xml:"managed,attr"`
-	Failed         bool   `xml:"failed,attr"`
-	FailureIgnored bool   `xml:"failure_ignored,attr"`
-	NodesRunningOn int    `xml:"nodes_running_on,attr"`
-}
-
 var (
 	// corosync metrics
 	corosyncRingErrorsTotal = prometheus.NewGauge(prometheus.GaugeOpts{

--- a/ha_cluster_exporter.go
+++ b/ha_cluster_exporter.go
@@ -200,25 +200,22 @@ func main() {
 				time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
 				continue
 			}
-			// TODO DELETE metrics ! since we can't know if volume get destroyed
+			// TODO 1: DELETE metrics ! since we can't know if volume get destroyed
 
 			// iterate over resources of drbd status
 			for _, resource := range drbdDev {
-
 				for _, device := range resource.Devices {
 					// 0 out of sync, 1 UpToDate, 2 Syncing
-					// lowercase the diskstates
+					// TODO 2:lowercase the diskstates
 					if "UpToDate" == resource.Devices[device.Volume].DiskState {
 						drbdDiskState.WithLabelValues(resource.Name, resource.Role, strconv.Itoa(device.Volume)).Set(float64(1))
 					}
-					// TODO: check this better and lowercase it
+					// TODO 3: check this better and lowercase it (we need to be sure how many states are there)
 					if "outofsync" == resource.Devices[device.Volume].DiskState {
 						drbdDiskState.WithLabelValues(resource.Name, resource.Role, strconv.Itoa(device.Volume)).Set(float64(1))
 					}
 				}
 			}
-			// set drbd metric
-			log.Println(drbdDev)
 			time.Sleep(time.Duration(int64(*timeoutSeconds)) * time.Second)
 		}
 	}()

--- a/pacemaker_metrics.go
+++ b/pacemaker_metrics.go
@@ -1,0 +1,56 @@
+package main
+
+// this types are for reading pacemaker configuration xml when running crm_mon command
+// and lookup the corrispective value
+type crmMon struct {
+	Version string  `xml:"version,attr"`
+	Summary summary `xml:"summary"`
+	Nodes   nodes   `xml:"nodes"`
+}
+
+type summary struct {
+	Nodes struct {
+		Number int `xml:"number,attr"`
+	} `xml:"nodes_configured"`
+	Resources resourcesConfigured `xml:"resources_configured"`
+}
+
+type resourcesConfigured struct {
+	Number   int `xml:"number,attr"`
+	Disabled int `xml:"disabled,attr"`
+	Blocked  int `xml:"blocked,attr"`
+}
+
+type nodes struct {
+	Node []node `xml:"node"`
+}
+
+type node struct {
+	Name             string     `xml:"name,attr"`
+	ID               string     `xml:"id,attr"`
+	Online           bool       `xml:"online,attr"`
+	Standby          bool       `xml:"standby,attr"`
+	StandbyOnFail    bool       `xml:"standby_onfail,attr"`
+	Maintenance      bool       `xml:"maintenance,attr"`
+	Pending          bool       `xml:"pending,attr"`
+	Unclean          bool       `xml:"unclean,attr"`
+	Shutdown         bool       `xml:"shutdown,attr"`
+	ExpectedUp       bool       `xml:"expected_up,attr"`
+	DC               bool       `xml:"is_dc,attr"`
+	ResourcesRunning int        `xml:"resources_running,attr"`
+	Type             string     `xml:"type,attr"`
+	Resources        []resource `xml:"resource"`
+}
+
+type resource struct {
+	ID             string `xml:"id,attr"`
+	Agent          string `xml:"resource_agent,attr"`
+	Role           string `xml:"role,attr"`
+	Active         bool   `xml:"active,attr"`
+	Orphaned       bool   `xml:"orphaned,attr"`
+	Blocked        bool   `xml:"blocked,attr"`
+	Managed        bool   `xml:"managed,attr"`
+	Failed         bool   `xml:"failed,attr"`
+	FailureIgnored bool   `xml:"failure_ignored,attr"`
+	NodesRunningOn int    `xml:"nodes_running_on,attr"`
+}

--- a/sbd_metrics.go
+++ b/sbd_metrics.go
@@ -25,16 +25,22 @@ func readSdbFile() ([]byte, error) {
 }
 
 // return a list of sbd devices that we get from config
-func getSbdDevices(sbdConfigRaw []byte) []string {
+func getSbdDevices(sbdConfigRaw []byte) ([]string, error) {
 	// in config it can be both SBD_DEVICE="/dev/foo" or SBD_DEVICE=/dev/foo;/dev/bro
 	wordOnly := regexp.MustCompile("SBD_DEVICE=\"?[a-zA-Z-/;]+\"?")
 	sbdDevicesConfig := wordOnly.FindString(string(sbdConfigRaw))
+
+	// check the case there is an sbd_config but the SBD_DEVICE is not set
+
+	if sbdDevicesConfig == "" {
+		return nil, fmt.Errorf("[ERROR] there are no SBD_DEVICE set in configuration file")
+	}
 	// remove the SBD_DEVICE
 	sbdArray := strings.Split(sbdDevicesConfig, "SBD_DEVICE=")[1]
 	// make a list of devices by ; seperators and remove double quotes if present
 	sbdDevices := strings.Split(strings.Trim(sbdArray, "\""), ";")
 
-	return sbdDevices
+	return sbdDevices, nil
 }
 
 // this function take a list of sbd devices and return

--- a/sbd_metrics_test.go
+++ b/sbd_metrics_test.go
@@ -125,7 +125,7 @@ func TestGetSbdDevicesWithoutDoubleQuotes(t *testing.T) {
 	 SBD_DEVICE=/dev/vdc;/dev/brother;/dev/syster																					
 			`
 
-	sbdDevices := getSbdDevices([]byte(sbdConfig))
+	sbdDevices, _ := getSbdDevices([]byte(sbdConfig))
 	// we should have 3 devices
 	expected := "/dev/vdc"
 	if sbdDevices[0] != expected {
@@ -173,7 +173,7 @@ func TestGetSbdDevicesWithDoubleQuotes(t *testing.T) {
 	 #
 	 SBD_OPTS=`
 
-	sbdDevices := getSbdDevices([]byte(sbdConfig))
+	sbdDevices, _ := getSbdDevices([]byte(sbdConfig))
 	// we should have 3 devices
 	expected := "/dev/vdc"
 	if sbdDevices[0] != expected {
@@ -208,7 +208,7 @@ func TestOnlyOneDeviceSbd(t *testing.T) {
 	 ## Default: "flush,reboot"
 `
 
-	sbdDevices := getSbdDevices([]byte(sbdConfig))
+	sbdDevices, _ := getSbdDevices([]byte(sbdConfig))
 
 	// we should have 1 device
 	expected := "/dev/vdc"

--- a/tools/deploy-to-cluster.sh
+++ b/tools/deploy-to-cluster.sh
@@ -4,7 +4,7 @@
 
 # this script is just for deploying the binary to the cluster. Nothing else.
 
-node="root@10.162.31.221"
+node="root@10.67.18.240"
 
 ssh $node "rm /root/ha_cluster_exporter"
 echo "copying binary"


### PR DESCRIPTION
# Description

This pr will implement this metric:

```

# HELP ha_cluster_drbd_resource_disk_state show per resource name, its role, the volume and disk_state (Diskless,Attaching, Failed, Negotiating, Inconsistent, Outdated, DUnknown, Consistent, UpToDate)
# TYPE ha_cluster_drbd_resource_disk_state gauge
ha_cluster_drbd_resource{disk_state="uptodate",resource_name="1-single-0",role="Secondary",volume="0"} 1
ha_cluster_drbd_resource{disk_state="uptodate",resource_name="1-single-1",role="Secondary",volume="0"} 1
ha_cluster_drbd_resource{disk_state="uptodate",resource_name="vg1",role="Secondary",volume="0"} 1
ha_cluster_drbd_resource{disk_state="uptodate",resource_name="vg2",role="Secondary",volume="0"} 1
ha_cluster_drbd_resource{disk_state="uptodate",resource_name="vg3",role="Secondary",volume="0"} 1
```

# Usage:

- Check if the state of DRBD disk are UptoDate, out of sync etc/
- monitor or alert drbd resource disks


## what is it is missing:

- [x] parse and populated types. 
- [x] Tests 
- [x] set the prometheus exporter metric according to metric

