### PR TITLE
Regarding Issue #28 - Fix SBD error in absence of SBD

### DIFF
--- a/ha_cluster_exporter.go
+++ b/ha_cluster_exporter.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -183,6 +184,10 @@ func main() {
 
 	// set SBD device metrics
 	go func() {
+		if _, err := os.Stat("/etc/sysconfig/sbd"); os.IsNotExist(err) {
+			return
+		}
+
 		for {
 			log.Println("[INFO]: Reading cluster SBD configuration..")
 			// read configuration of SBD


### PR DESCRIPTION
This is in relation #28 and proposes a quick fix to resolve errors seen when `/etc/sysconfig/sbd` is not present on the machine. 