### PR TITLE
add remote disk metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ default: build
 
 build: fmt-check  vet-check test
 	go build .
+	go mod tidy
 
 install:
 	go install

--- a/corosync_metrics.go
+++ b/corosync_metrics.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -12,11 +12,15 @@ import (
 // Quorum metrics
 
 // return the output of quorum in raw format
-func getQuoromClusterInfo() []byte {
+func getQuoromClusterInfo() ([]byte, error) {
 	// ignore error because If any interfaces are faulty, 1 is returned by the binary. If all interfaces
 	// are active 0 is returned to the shell.
+	if _, err := os.Stat("/usr/sbin/corosync-quorumtool"); os.IsNotExist(err) {
+		return nil, fmt.Errorf("could not find corosync-quromtool binary")
+	}
+
 	quorumInfoRaw, _ := exec.Command("/usr/sbin/corosync-quorumtool").Output()
-	return quorumInfoRaw
+	return quorumInfoRaw, nil
 }
 
 func parseQuoromStatus(quoromStatus []byte) (map[string]int, string, error) {
@@ -36,6 +40,16 @@ func parseQuoromStatus(quoromStatus []byte) (map[string]int, string, error) {
 	// and convert it to integer type
 	numberOnly := regexp.MustCompile("[0-9]+")
 	wordOnly := regexp.MustCompile("[a-zA-Z]+")
+	quoratePresent := regexp.MustCompile("Quorate:")
+
+	// In case of error, the binary is there but execution was erroring out, check output for quorate string.
+	quorateWordPresent := quoratePresent.FindString(string(quoromRaw))
+
+	// check the case there is an sbd_config but the SBD_DEVICE is not set
+
+	if quorateWordPresent == "" {
+		return nil, "", fmt.Errorf("the quorum status output is not in parsable format as expected")
+	}
 
 	quorateRaw := wordOnly.FindString(strings.SplitAfterN(quoromRaw, "Quorate:", 2)[1])
 	quorate := strings.ToLower(quorateRaw)
@@ -52,7 +66,7 @@ func parseQuoromStatus(quoromStatus []byte) (map[string]int, string, error) {
 	}
 
 	if len(voteQuorumInfo) == 0 {
-		return voteQuorumInfo, quorate, errors.New("could not retrieve any quorum information")
+		return voteQuorumInfo, quorate, fmt.Errorf("could not retrieve any quorum information")
 	}
 
 	return voteQuorumInfo, quorate, nil

--- a/drbd_metrics.go
+++ b/drbd_metrics.go
@@ -13,6 +13,14 @@ type drbdStatus struct {
 		Volume    int    `json:"volume"`
 		DiskState string `json:"disk-state"`
 	} `json:"devices"`
+	Connections []struct {
+		PeerNodeID  int    `json:"peer-node-id"`
+		PeerRole    string `json:"peer-role"`
+		PeerDevices []struct {
+			Volume        int    `json:"volume"`
+			PeerDiskState string `json:"peer-disk-state"`
+		} `json:"peer_devices"`
+	} `json:"connections"`
 }
 
 // return drbd status in byte raw json

--- a/drbd_metrics_test.go
+++ b/drbd_metrics_test.go
@@ -123,6 +123,14 @@ func TestDrbdParsing(t *testing.T) {
 		t.Errorf("disk-states doesn't correspond! fail got %s", drbdDevs[0].Devices[0].DiskState)
 	}
 
+	if 1 != drbdDevs[0].Connections[0].PeerNodeID {
+		t.Errorf("peerNodeID doesn't correspond! fail got %d", drbdDevs[0].Connections[0].PeerNodeID)
+	}
+
+	if "UpToDate" != drbdDevs[0].Connections[0].PeerDevices[0].PeerDiskState {
+		t.Errorf("peerDiskState doesn't correspond! fail got %s", drbdDevs[0].Connections[0].PeerDevices[0].PeerDiskState)
+	}
+
 	if 0 != drbdDevs[0].Devices[0].Volume {
 		t.Errorf("volumes should be 0")
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module github.com/ClusterLabs/ha_cluster_exporter
 go 1.12
 
 require (
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/prometheus/client_golang v1.1.0
 	github.com/sirupsen/logrus v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/ClusterLabs/ha_cluster_exporter
 go 1.12
 
 require (
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/prometheus/client_golang v1.1.0
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -32,6 +33,7 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -53,6 +55,7 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
# desc:

1) create a metric like

```
# HELP ha_cluster_drbd_resources_remote_connection show per remote connection resource name, its role, the volume and disk_state (Diskless,Attaching, Failed, Negotiating, Inconsistent, Outdated, DUnknown, Consistent, UpToDate)
# TYPE ha_cluster_drbd_resources_remote_connection gauge
ha_cluster_drbd_resources_remote_connection{peer_disk_state="dunknown",peer_node_id="0",peer_role="Unknown",resource_name="drbd_passive",volume="0"} 1
```

2) fix some error handling things:
 - use warn instead of error
 - other minor refactor and improvements