### PR TITLE
Feature: add stonith metric

### DIFF
--- a/doc/metric_spec.md
+++ b/doc/metric_spec.md
@@ -28,6 +28,7 @@ The Pacemaker subsystem collects an atomic snapshot of the HA cluster directly f
 2. [`ha_cluster_pacemaker_nodes_total`](#ha_cluster_pacemaker_nodes_total)
 3. [`ha_cluster_pacemaker_resources`](#ha_cluster_pacemaker_resources)
 4. [`ha_cluster_pacemaker_resources_total`](#ha_cluster_pacemaker_resources_total)
+5. [`ha_cluster_pacemaker_stonith_enabled`](#ha_cluster_pacemaker_stonith_enabled)
 
 
 ### `ha_cluster_pacemaker_nodes`
@@ -77,6 +78,13 @@ The total number of lines for this metric will be the cardinality of `id` times 
 
 The total number of *configured* resources in the cluster. This value is mostly static and *does not* take into account the status of the resources. It only changes when the Pacemaker configuration changes.
 
+
+### `ha_cluster_pacemaker_stonith_enabled`
+
+#### Description
+
+Whether or not stonith is enabled in the cluster.  
+Value is either `1` or `0`.
 
 ## Corosync
 

--- a/pacemaker_metrics.go
+++ b/pacemaker_metrics.go
@@ -81,7 +81,7 @@ var (
 		"nodes_total":     NewMetricDesc("pacemaker", "nodes_total", "Total number of nodes in the cluster", nil),
 		"resources":       NewMetricDesc("pacemaker", "resources", "The resources in the cluster; one line per id, per status", []string{"node", "id", "role", "managed", "status"}),
 		"resources_total": NewMetricDesc("pacemaker", "resources_total", "Total number of resources in the cluster", nil),
-		"stonith_enabled": NewMetricDesc("pacemaker", "stonith_enabled", "Wether or not stonith is enabled for the cluster; 1 is yes, 0 is no", nil),
+		"stonith_enabled": NewMetricDesc("pacemaker", "stonith_enabled", "Whether or not stonith is enabled", nil),
 	}
 
 	crmMonPath = "/usr/sbin/crm_mon"

--- a/pacemaker_metrics.go
+++ b/pacemaker_metrics.go
@@ -23,7 +23,8 @@ type summary struct {
 	Nodes struct {
 		Number int `xml:"number,attr"`
 	} `xml:"nodes_configured"`
-	Resources resourcesConfigured `xml:"resources_configured"`
+	Resources      resourcesConfigured `xml:"resources_configured"`
+	ClusterOptions clusterOptions      `xml:"cluster_options"`
 }
 
 type resourcesConfigured struct {
@@ -34,6 +35,10 @@ type resourcesConfigured struct {
 
 type nodes struct {
 	Node []node `xml:"node"`
+}
+
+type clusterOptions struct {
+	StonithEnabled bool `xml:"stonith-enabled,attr"`
 }
 
 type node struct {
@@ -76,6 +81,7 @@ var (
 		"nodes_total":     NewMetricDesc("pacemaker", "nodes_total", "Total number of nodes in the cluster", nil),
 		"resources":       NewMetricDesc("pacemaker", "resources", "The resources in the cluster; one line per id, per status", []string{"node", "id", "role", "managed", "status"}),
 		"resources_total": NewMetricDesc("pacemaker", "resources_total", "Total number of resources in the cluster", nil),
+		"stonith_enabled": NewMetricDesc("pacemaker", "stonith_enabled", "Wether or not stonith is enabled for the cluster; 1 is yes, 0 is no", nil),
 	}
 
 	crmMonPath = "/usr/sbin/crm_mon"
@@ -113,8 +119,14 @@ func (c *pacemakerCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
+	var stonithEnabled float64
+	if pacemakerStatus.Summary.ClusterOptions.StonithEnabled {
+		stonithEnabled = 1
+	}
+
 	ch <- c.makeGaugeMetric("nodes_total", float64(pacemakerStatus.Summary.Nodes.Number))
 	ch <- c.makeGaugeMetric("resources_total", float64(pacemakerStatus.Summary.Resources.Number))
+	ch <- c.makeGaugeMetric("stonith_enabled", stonithEnabled)
 
 	c.recordNodeMetrics(pacemakerStatus, ch)
 }

--- a/test/pacemaker.metrics
+++ b/test/pacemaker.metrics
@@ -19,6 +19,6 @@ ha_cluster_pacemaker_resources{id="stonith-sbd",managed="true",node="hana01",rol
 # HELP ha_cluster_pacemaker_resources_total Total number of resources in the cluster
 # TYPE ha_cluster_pacemaker_resources_total gauge
 ha_cluster_pacemaker_resources_total 6 1234
-# HELP ha_cluster_pacemaker_stonith_enabled Wether or not stonith is enabled for the cluster; 1 is yes, 0 is no
+# HELP ha_cluster_pacemaker_stonith_enabled Whether or not stonith is enabled
 # TYPE ha_cluster_pacemaker_stonith_enabled gauge
 ha_cluster_pacemaker_stonith_enabled 1 1234

--- a/test/pacemaker.metrics
+++ b/test/pacemaker.metrics
@@ -19,3 +19,6 @@ ha_cluster_pacemaker_resources{id="stonith-sbd",managed="true",node="hana01",rol
 # HELP ha_cluster_pacemaker_resources_total Total number of resources in the cluster
 # TYPE ha_cluster_pacemaker_resources_total gauge
 ha_cluster_pacemaker_resources_total 6 1234
+# HELP ha_cluster_pacemaker_stonith_enabled Wether or not stonith is enabled for the cluster; 1 is yes, 0 is no
+# TYPE ha_cluster_pacemaker_stonith_enabled gauge
+ha_cluster_pacemaker_stonith_enabled 1 1234


### PR DESCRIPTION
follow up from #66 and #67:

add the new `ha_cluster_pacemaker_stonith_enabled` metric, exemplified [here](https://github.com/stefanotorresi/ha_cluster_exporter/blob/63bad1d33193b1acc23ab82be08b8270efbbc6d1/test/pacemaker.metrics#L22-L24)