### PR TITLE
Implement ban constraint metric

### DIFF
--- a/pacemaker_metrics_test.go
+++ b/pacemaker_metrics_test.go
@@ -65,7 +65,9 @@ func TestParsePacemakerXML(t *testing.T) {
 		<tickets>
 		</tickets>
 		<bans>
-		</bans>
+     		<ban id="cli-ban-msl_SAPHana_PRD_HDB00-on-damadog-hana01" resource="msl_SAPHana_PRD_HDB00" node="damadog-hana01" weight="-1000000" master_only="false" />
+			<ban id="cli-ban-msl_SAPHana_PRD_HDB00-on-damadog-hana02" resource="msl_SAPHana_PRD_HDB002" node="damadog-hana01" weight="-1000000" master_only="false" />
+	    </bans>
 	</crm_mon>`
 
 	status, err := parsePacemakerStatus([]byte(pacemakerxml))
@@ -77,6 +79,13 @@ func TestParsePacemakerXML(t *testing.T) {
 		t.Errorf("Version was incorrect, got: %s, expected: %s ", status.Version, "2.0.0")
 	}
 
+	if status.Bans.Ban[0].ID != "cli-ban-msl_SAPHana_PRD_HDB00-on-damadog-hana01" {
+		t.Errorf("ban constraint incorrect, got: %s, expected: cli-ban-msl_SAPHana_PRD_HDB00-on-damadog-hana01", status.Bans.Ban[0].ID)
+	}
+
+	if status.Bans.Ban[0].ID != "cli-ban-msl_SAPHana_PRD_HDB00-on-damadog-hana01" {
+		t.Errorf("ban constraint incorrect, got: %s, expected: cli-ban-msl_SAPHana_PRD_HDB00-on-damadog-hana01", status.Bans.Ban[0].ID)
+	}
 	var expected int
 	expected = 3
 

--- a/test/fake_crm_mon.sh
+++ b/test/fake_crm_mon.sh
@@ -84,7 +84,7 @@ cat <<EOF
     </node_history>
     <tickets>
     </tickets>
-      <bans>
+    <bans>
         <ban id="cli-ban-msl_SAPHana_PRD_HDB00-on-damadog-hana01" resource="msl_SAPHana_PRD_HDB00" node="damadog-hana01" weight="-1000000" master_only="false" />
     </bans>
 </crm_mon>

--- a/test/pacemaker.metrics
+++ b/test/pacemaker.metrics
@@ -1,6 +1,9 @@
 # HELP ha_cluster_pacemaker_config_last_change Indicate if a configuration of resource has changed in cluster
 # TYPE ha_cluster_pacemaker_config_last_change counter
 ha_cluster_pacemaker_config_last_change 1 1571399302000
+# HELP ha_cluster_pacemaker_constraints Indicate if a constraints of specific type is present per resource ID
+# TYPE ha_cluster_pacemaker_constraints gauge
+ha_cluster_pacemaker_constraints{id="cli-ban-msl_SAPHana_PRD_HDB00-on-damadog-hana01",type="ban"} 1 1234
 # HELP ha_cluster_pacemaker_fail_count The Fail count number per node and resource id
 # TYPE ha_cluster_pacemaker_fail_count gauge
 ha_cluster_pacemaker_fail_count{node="hana01",resource="rsc_SAPHanaTopology_PRD_HDB00"} 0 1234
@@ -41,4 +44,3 @@ ha_cluster_pacemaker_resources_total 6 1234
 # HELP ha_cluster_pacemaker_stonith_enabled Whether or not stonith is enabled
 # TYPE ha_cluster_pacemaker_stonith_enabled gauge
 ha_cluster_pacemaker_stonith_enabled 1 1234
-


### PR DESCRIPTION
implement a metric for ban constraints.

```

# HELP ha_cluster_pacemaker_constraints Indicate if some constraints of different type is present on cluster for resource ID
# TYPE ha_cluster_pacemaker_constraints gauge
ha_cluster_pacemaker_constraints{id="cli-ban-msl_SAPHana_PRD_HDB00-on-damadog-hana01",type="ban"} 1 1234
```