### PR TITLE
Change DRBD percent from int to Float

### DIFF
--- a/doc/metric_spec.md
+++ b/doc/metric_spec.md
@@ -206,7 +206,7 @@ The total number of lines for this metric will be the cardinality of `resource` 
 
 #### Descriptions
 
-The DRBD disk connections in sync percentage. Values from 0 to 100.
+The DRBD disk connections in sync percentage. Values are float from `0` to `100.00`.
 
 ### `ha_cluster_drbd_resources`
 

--- a/drbd_metrics.go
+++ b/drbd_metrics.go
@@ -24,9 +24,9 @@ type drbdStatus struct {
 		PeerNodeID  int    `json:"peer-node-id"`
 		PeerRole    string `json:"peer-role"`
 		PeerDevices []struct {
-			Volume        int    `json:"volume"`
-			PeerDiskState string `json:"peer-disk-state"`
-			PercentInSync int    `json:"percent-in-sync"`
+			Volume        int     `json:"volume"`
+			PeerDiskState string  `json:"peer-disk-state"`
+			PercentInSync float64 `json:"percent-in-sync"`
 		} `json:"peer_devices"`
 	} `json:"connections"`
 }

--- a/drbd_metrics_test.go
+++ b/drbd_metrics_test.go
@@ -146,7 +146,7 @@ func TestDrbdParsing(t *testing.T) {
 	}
 
 	if 99.8 != drbdDevs[1].Connections[0].PeerDevices[0].PercentInSync {
-		t.Errorf("Float PercentInSync doesn't correspond! fail got %f", drbdDevs[0].Connections[0].PeerDevices[0].PercentInSync)
+		t.Errorf("Float PercentInSync doesn't correspond! fail got %f", drbdDevs[1].Connections[0].PeerDevices[0].PercentInSync)
 	}
 
 }

--- a/drbd_metrics_test.go
+++ b/drbd_metrics_test.go
@@ -103,7 +103,7 @@ func TestDrbdParsing(t *testing.T) {
             "unacked": 0,
             "has-sync-details": false,
             "has-online-verify-details": false,
-            "percent-in-sync": 100
+            "percent-in-sync": 99.8
           }
         ]
       }
@@ -142,7 +142,11 @@ func TestDrbdParsing(t *testing.T) {
 	}
 
 	if 100 != drbdDevs[0].Connections[0].PeerDevices[0].PercentInSync {
-		t.Errorf("PercentInSync doesn't correspond! fail got %d", drbdDevs[0].Connections[0].PeerDevices[0].PercentInSync)
+		t.Errorf("PercentInSync doesn't correspond! fail got %f", drbdDevs[0].Connections[0].PeerDevices[0].PercentInSync)
+	}
+
+	if 99.8 != drbdDevs[1].Connections[0].PeerDevices[0].PercentInSync {
+		t.Errorf("Float PercentInSync doesn't correspond! fail got %f", drbdDevs[0].Connections[0].PeerDevices[0].PercentInSync)
 	}
 
 }


### PR DESCRIPTION
The percentage value generated on `drbdsetup` tool can present a float value depending on the DRBD version. Using float should work for all situations.