### PR TITLE
Fix matching labels and case sensitivity

### DIFF
--- a/drbd_metrics.go
+++ b/drbd_metrics.go
@@ -34,7 +34,7 @@ var (
 	drbdMetrics = metricDescriptors{
 		// the map key will function as an identifier of the metric throughout the rest of the code;
 		// it is arbitrary, but by convention we use the actual metric name
-		"resources":        NewMetricDesc("drbd", "resources", "The DRBD resources; 1 line per name, per volume", []string{"name", "role", "volume", "disk_state"}),
+		"resources":        NewMetricDesc("drbd", "resources", "The DRBD resources; 1 line per name, per volume", []string{"resource", "role", "volume", "disk_state"}),
 		"connections":      NewMetricDesc("drbd", "connections", "The DRBD resource connections; 1 line per per resource, per peer_node_id", []string{"resource", "peer_node_id", "peer_role", "volume", "peer_disk_state"}),
 		"connections_sync": NewMetricDesc("drbd", "connections_sync", "The in sync percentage value for DRBD resource connections", []string{"resource", "peer_node_id", "volume"}),
 	}

--- a/pacemaker_metrics.go
+++ b/pacemaker_metrics.go
@@ -89,9 +89,9 @@ var (
 	pacemakerMetrics = metricDescriptors{
 		// the map key will function as an identifier of the metric throughout the rest of the code;
 		// it is arbitrary, but by convention we use the actual metric name
-		"nodes":               NewMetricDesc("pacemaker", "nodes", "The nodes in the cluster; one line per name, per status", []string{"name", "type", "status"}),
+		"nodes":               NewMetricDesc("pacemaker", "nodes", "The nodes in the cluster; one line per name, per status", []string{"node", "type", "status"}),
 		"nodes_total":         NewMetricDesc("pacemaker", "nodes_total", "Total number of nodes in the cluster", nil),
-		"resources":           NewMetricDesc("pacemaker", "resources", "The resources in the cluster; one line per id, per status", []string{"node", "id", "role", "managed", "status"}),
+		"resources":           NewMetricDesc("pacemaker", "resources", "The resources in the cluster; one line per id, per status", []string{"node", "resource", "role", "managed", "status"}),
 		"resources_total":     NewMetricDesc("pacemaker", "resources_total", "Total number of resources in the cluster", nil),
 		"stonith_enabled":     NewMetricDesc("pacemaker", "stonith_enabled", "Whether or not stonith is enabled", nil),
 		"fail_count":          NewMetricDesc("pacemaker", "fail_count", "The Fail count number per node and resource id", []string{"node", "resource"}),
@@ -221,7 +221,7 @@ func (c *pacemakerCollector) recordResourcesMetrics(node node, ch chan<- prometh
 					"resources",
 					float64(1),
 					node.Name,
-					strings.ToLower(resource.ID),
+					resource.ID,
 					strings.ToLower(resource.Role),
 					strconv.FormatBool(resource.Managed),
 					resourceStatus)

--- a/test/drbd.metrics
+++ b/test/drbd.metrics
@@ -8,5 +8,5 @@ ha_cluster_drbd_connections_sync{peer_node_id="1",resource="1-single-0",volume="
 ha_cluster_drbd_connections_sync{peer_node_id="1",resource="1-single-1",volume="0"} 100 1234
 # HELP ha_cluster_drbd_resources The DRBD resources; 1 line per name, per volume
 # TYPE ha_cluster_drbd_resources gauge
-ha_cluster_drbd_resources{disk_state="uptodate",name="1-single-0",role="Secondary",volume="0"} 1 1234
-ha_cluster_drbd_resources{disk_state="uptodate",name="1-single-1",role="Secondary",volume="0"} 1 1234
+ha_cluster_drbd_resources{disk_state="uptodate",resource="1-single-0",role="Secondary",volume="0"} 1 1234
+ha_cluster_drbd_resources{disk_state="uptodate",resource="1-single-1",role="Secondary",volume="0"} 1 1234

--- a/test/pacemaker.metrics
+++ b/test/pacemaker.metrics
@@ -24,22 +24,22 @@ ha_cluster_pacemaker_migration_threshold{node="hana02",resource="rsc_SAPHanaTopo
 ha_cluster_pacemaker_migration_threshold{node="hana02",resource="rsc_SAPHana_PRD_HDB00"} 50 1234
 # HELP ha_cluster_pacemaker_nodes The nodes in the cluster; one line per name, per status
 # TYPE ha_cluster_pacemaker_nodes gauge
-ha_cluster_pacemaker_nodes{name="hana01",status="dc",type="member"} 1 1234
-ha_cluster_pacemaker_nodes{name="hana01",status="expected_up",type="member"} 1 1234
-ha_cluster_pacemaker_nodes{name="hana01",status="online",type="member"} 1 1234
-ha_cluster_pacemaker_nodes{name="hana02",status="expected_up",type="member"} 1 1234
-ha_cluster_pacemaker_nodes{name="hana02",status="online",type="member"} 1 1234
+ha_cluster_pacemaker_nodes{node="hana01",status="dc",type="member"} 1 1234
+ha_cluster_pacemaker_nodes{node="hana01",status="expected_up",type="member"} 1 1234
+ha_cluster_pacemaker_nodes{node="hana01",status="online",type="member"} 1 1234
+ha_cluster_pacemaker_nodes{node="hana02",status="expected_up",type="member"} 1 1234
+ha_cluster_pacemaker_nodes{node="hana02",status="online",type="member"} 1 1234
 # HELP ha_cluster_pacemaker_nodes_total Total number of nodes in the cluster
 # TYPE ha_cluster_pacemaker_nodes_total gauge
 ha_cluster_pacemaker_nodes_total 2 1234
 # HELP ha_cluster_pacemaker_resources The resources in the cluster; one line per id, per status
 # TYPE ha_cluster_pacemaker_resources gauge
-ha_cluster_pacemaker_resources{id="rsc_ip_prd_hdb00",managed="true",node="hana01",role="started",status="active"} 1 1234
-ha_cluster_pacemaker_resources{id="rsc_saphana_prd_hdb00",managed="true",node="hana01",role="master",status="active"} 1 1234
-ha_cluster_pacemaker_resources{id="rsc_saphana_prd_hdb00",managed="true",node="hana02",role="slave",status="active"} 1 1234
-ha_cluster_pacemaker_resources{id="rsc_saphanatopology_prd_hdb00",managed="true",node="hana01",role="started",status="active"} 1 1234
-ha_cluster_pacemaker_resources{id="rsc_saphanatopology_prd_hdb00",managed="true",node="hana02",role="started",status="active"} 1 1234
-ha_cluster_pacemaker_resources{id="stonith-sbd",managed="true",node="hana01",role="started",status="active"} 1 1234
+ha_cluster_pacemaker_resources{managed="true",node="hana01",resource="rsc_ip_PRD_HDB00",role="started",status="active"} 1 1234
+ha_cluster_pacemaker_resources{managed="true",node="hana01",resource="rsc_SAPHana_PRD_HDB00",role="master",status="active"} 1 1234
+ha_cluster_pacemaker_resources{managed="true",node="hana01",resource="rsc_SAPHanaTopology_PRD_HDB00",role="started",status="active"} 1 1234
+ha_cluster_pacemaker_resources{managed="true",node="hana01",resource="stonith-sbd",role="started",status="active"} 1 1234
+ha_cluster_pacemaker_resources{managed="true",node="hana02",resource="rsc_SAPHana_PRD_HDB00",role="slave",status="active"} 1 1234
+ha_cluster_pacemaker_resources{managed="true",node="hana02",resource="rsc_SAPHanaTopology_PRD_HDB00",role="started",status="active"} 1 1234
 # HELP ha_cluster_pacemaker_resources_total Total number of resources in the cluster
 # TYPE ha_cluster_pacemaker_resources_total gauge
 ha_cluster_pacemaker_resources_total 6 1234


### PR DESCRIPTION
While using the metrics in Grafana I realized that using the common convention of differentiating discriminator fields between "owning" and "joined" side, which I borrowed from RDBMS, doesn't really work with Prometheus time series.

One example of this was 
````
ha_cluster_pacemaker_resources{id="foo"}
ha_cluster_pacemaker_fail_count{resource="foo"}
````
Originally, it was intentional to use distinct labels, because I thought Prometheus would allow specifying the label names to match in aggregated queries using `on` `group_*` and `by`, but I have only now found out that this is not the case: the label are actually assumed to have the same name.  
Grafana also has a few functionalities that work under this assumption.

This PR also fixes a bug where the resource name was mistakenly processed with `strings.ToLower`, which would also produce unexpected results with the aforementioned kind of queries.

The presented changeset constitutes a definite breaking change, that will need to be properly disclosed during the release.