### PR TITLE
Add quorum status to DRBD metrics

### DIFF
--- a/doc/metric_spec.md
+++ b/doc/metric_spec.md
@@ -211,13 +211,14 @@ The DRBD subsystems collect devices stats by parsing its configuration the JSON 
 5. [`ha_cluster_drbd_bm_writes`](#ha_cluster_bm_writes)
 6. [`ha_cluster_drbd_upper_pending`](#ha_cluster_drbd_upper_pending)
 7. [`ha_cluster_drbd_lower_pending`](#ha_cluster_drbd_lower_pending)
-8. [`ha_cluster_drbd_connections`](#ha_cluster_drbd_connections)
-9. [`ha_cluster_drbd_connections_sync`](#ha_cluster_drbd_connections_sync)
-10. [`ha_cluster_drbd_connections_received`](#ha_cluster_drbd_connections_received)
-11. [`ha_cluster_drbd_connections_sent`](#ha_cluster_drbd_connections_sent)
-12. [`ha_cluster_drbd_connections_pending`](#ha_cluster_drbd_connections_pending)
-13. [`ha_cluster_drbd_connections_unacked`](#ha_cluster_drbd_connections_unacked)
-14. [`ha_cluster_drbd_split_brain`](#ha_cluster_drbd_split_brain)
+8. [`ha_cluster_drbd_quorum`](#ha_cluster_drbd_quorum)
+9. [`ha_cluster_drbd_connections`](#ha_cluster_drbd_connections)
+10. [`ha_cluster_drbd_connections_sync`](#ha_cluster_drbd_connections_sync)
+11. [`ha_cluster_drbd_connections_received`](#ha_cluster_drbd_connections_received)
+12. [`ha_cluster_drbd_connections_sent`](#ha_cluster_drbd_connections_sent)
+13. [`ha_cluster_drbd_connections_pending`](#ha_cluster_drbd_connections_pending)
+14. [`ha_cluster_drbd_connections_unacked`](#ha_cluster_drbd_connections_unacked)
+15. [`ha_cluster_drbd_split_brain`](#ha_cluster_drbd_split_brain)
 
 ### `ha_cluster_drbd_connections`
 
@@ -382,6 +383,18 @@ Value is an integer greater than or equal to `0`.
 
 Number of open requests to the local I/O sub-system issued by DRBD; 1 line per `resource`, per `volume`
 Value is an integer greater than or equal to `0`.
+
+#### Labels
+
+- `resource`: the name of the resource.
+- `volume`: the volume number
+
+### `ha_cluster_drbd_quorum`
+
+#### Description
+
+Quorum status of the DRBD resource according to it's configured quorum policies; 1 line per `resource`, per `volume`
+Value is `1` when quorate, or `0` when inquorate.
 
 #### Labels
 

--- a/drbd_metrics.go
+++ b/drbd_metrics.go
@@ -54,7 +54,7 @@ var (
 		"bm_writes":            NewMetricDesc("drbd", "bm_writes", "Writes to bitmap; 1 line per res, per volume", []string{"resource", "volume"}),
 		"upper_pending":        NewMetricDesc("drbd", "upper_pending", "Upper pending; 1 line per res, per volume", []string{"resource", "volume"}),
 		"lower_pending":        NewMetricDesc("drbd", "lower_pending", "Lower pending; 1 line per res, per volume", []string{"resource", "volume"}),
-		"quorum":               NewMetricDesc("drbd", "quorum", "Quorum status; 1 line per res, per volume", []string{"resource", "volume"}),
+		"quorum":               NewMetricDesc("drbd", "quorum", "Quorum status per resource and per volume", []string{"resource", "volume"}),
 		"connections":          NewMetricDesc("drbd", "connections", "The DRBD resource connections; 1 line per per resource, per peer_node_id", []string{"resource", "peer_node_id", "peer_role", "volume", "peer_disk_state"}),
 		"connections_sync":     NewMetricDesc("drbd", "connections_sync", "The in sync percentage value for DRBD resource connections", []string{"resource", "peer_node_id", "volume"}),
 		"connections_received": NewMetricDesc("drbd", "connections_received", "KiB received per connection", []string{"resource", "peer_node_id", "volume"}),

--- a/drbd_metrics.go
+++ b/drbd_metrics.go
@@ -25,6 +25,7 @@ type drbdStatus struct {
 		BmWrites  int    `json:"bm-writes"`
 		UpPending int    `json:"upper-pending"`
 		LoPending int    `json:"lower-pending"`
+		Quorum    bool   `json:"quorum"`
 		DiskState string `json:"disk-state"`
 	} `json:"devices"`
 	Connections []struct {
@@ -53,6 +54,7 @@ var (
 		"bm_writes":            NewMetricDesc("drbd", "bm_writes", "Writes to bitmap; 1 line per res, per volume", []string{"resource", "volume"}),
 		"upper_pending":        NewMetricDesc("drbd", "upper_pending", "Upper pending; 1 line per res, per volume", []string{"resource", "volume"}),
 		"lower_pending":        NewMetricDesc("drbd", "lower_pending", "Lower pending; 1 line per res, per volume", []string{"resource", "volume"}),
+		"quorum":               NewMetricDesc("drbd", "quorum", "Quorum status; 1 line per res, per volume", []string{"resource", "volume"}),
 		"connections":          NewMetricDesc("drbd", "connections", "The DRBD resource connections; 1 line per per resource, per peer_node_id", []string{"resource", "peer_node_id", "peer_role", "volume", "peer_disk_state"}),
 		"connections_sync":     NewMetricDesc("drbd", "connections_sync", "The in sync percentage value for DRBD resource connections", []string{"resource", "peer_node_id", "volume"}),
 		"connections_received": NewMetricDesc("drbd", "connections_received", "KiB received per connection", []string{"resource", "peer_node_id", "volume"}),
@@ -121,6 +123,12 @@ func (c *drbdCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- c.makeGaugeMetric("upper_pending", float64(device.UpPending), resource.Name, strconv.Itoa(device.Volume))
 
 			ch <- c.makeGaugeMetric("lower_pending", float64(device.LoPending), resource.Name, strconv.Itoa(device.Volume))
+
+			if bool(device.Quorum) == true {
+				ch <- c.makeGaugeMetric("quorum", float64(1), resource.Name, strconv.Itoa(device.Volume))
+			} else {
+				ch <- c.makeGaugeMetric("quorum", float64(0), resource.Name, strconv.Itoa(device.Volume))
+			}
 		}
 		if len(resource.Connections) == 0 {
 			log.Warnf("Could not retrieve connection info for resource '%s'\n", resource.Name)

--- a/drbd_metrics_test.go
+++ b/drbd_metrics_test.go
@@ -178,15 +178,7 @@ func TestDrbdParsing(t *testing.T) {
 		t.Errorf("received should be 456")
 	}
 
-	if 456 != drbdDevs[1].Connections[0].PeerDevices[0].Received {
-		t.Errorf("received should be 456")
-	}
-
 	if 654 != drbdDevs[0].Connections[0].PeerDevices[0].Sent {
-		t.Errorf("sent should be 654")
-	}
-
-	if 654 != drbdDevs[1].Connections[0].PeerDevices[0].Sent {
 		t.Errorf("sent should be 654")
 	}
 
@@ -194,15 +186,7 @@ func TestDrbdParsing(t *testing.T) {
 		t.Errorf("pending should be 3")
 	}
 
-	if 3 != drbdDevs[1].Connections[0].PeerDevices[0].Pending {
-		t.Errorf("pending should be 3")
-	}
-
 	if 4 != drbdDevs[0].Connections[0].PeerDevices[0].Unacked {
-		t.Errorf("unacked should be 4")
-	}
-
-	if 4 != drbdDevs[1].Connections[0].PeerDevices[0].Unacked {
 		t.Errorf("unacked should be 4")
 	}
 

--- a/drbd_metrics_test.go
+++ b/drbd_metrics_test.go
@@ -71,7 +71,7 @@ func TestDrbdParsing(t *testing.T) {
         "minor": 3,
         "disk-state": "UpToDate",
         "client": false,
-        "quorum": true,
+        "quorum": false,
         "size": 10200,
         "read": 654321,
         "written": 123456,
@@ -170,8 +170,8 @@ func TestDrbdParsing(t *testing.T) {
 		t.Errorf("quorum should be true")
 	}
 
-	if true != drbdDevs[1].Devices[0].Quorum {
-		t.Errorf("quorum should be true")
+	if false != drbdDevs[1].Devices[0].Quorum {
+		t.Errorf("quorum should be false")
 	}
 
 	if 456 != drbdDevs[0].Connections[0].PeerDevices[0].Received {

--- a/drbd_metrics_test.go
+++ b/drbd_metrics_test.go
@@ -166,7 +166,19 @@ func TestDrbdParsing(t *testing.T) {
 		t.Errorf("lower-pending should be 2")
 	}
 
+	if true != drbdDevs[0].Devices[0].Quorum {
+		t.Errorf("quorum should be true")
+	}
+
+	if true != drbdDevs[1].Devices[0].Quorum {
+		t.Errorf("quorum should be true")
+	}
+
 	if 456 != drbdDevs[0].Connections[0].PeerDevices[0].Received {
+		t.Errorf("received should be 456")
+	}
+
+	if 456 != drbdDevs[1].Connections[0].PeerDevices[0].Received {
 		t.Errorf("received should be 456")
 	}
 
@@ -174,11 +186,23 @@ func TestDrbdParsing(t *testing.T) {
 		t.Errorf("sent should be 654")
 	}
 
+	if 654 != drbdDevs[1].Connections[0].PeerDevices[0].Sent {
+		t.Errorf("sent should be 654")
+	}
+
 	if 3 != drbdDevs[0].Connections[0].PeerDevices[0].Pending {
 		t.Errorf("pending should be 3")
 	}
 
+	if 3 != drbdDevs[1].Connections[0].PeerDevices[0].Pending {
+		t.Errorf("pending should be 3")
+	}
+
 	if 4 != drbdDevs[0].Connections[0].PeerDevices[0].Unacked {
+		t.Errorf("unacked should be 4")
+	}
+
+	if 4 != drbdDevs[1].Connections[0].PeerDevices[0].Unacked {
 		t.Errorf("unacked should be 4")
 	}
 

--- a/test/drbd.metrics
+++ b/test/drbd.metrics
@@ -46,6 +46,10 @@ ha_cluster_drbd_upper_pending{resource="1-single-1",volume="0"} 1 1234
 # TYPE ha_cluster_drbd_lower_pending gauge
 ha_cluster_drbd_lower_pending{resource="1-single-0",volume="0"} 2 1234
 ha_cluster_drbd_lower_pending{resource="1-single-1",volume="0"} 2 1234
+# HELP ha_cluster_drbd_quorum Quorum status; 1 line per res, per volume
+# TYPE ha_cluster_drbd_quorum gauge
+ha_cluster_drbd_quorum{resource="1-single-0",volume="0"} 1 1234
+ha_cluster_drbd_quorum{resource="1-single-1",volume="0"} 1 1234
 # HELP ha_cluster_drbd_resources The DRBD resources; 1 line per name, per volume
 # TYPE ha_cluster_drbd_resources gauge
 ha_cluster_drbd_resources{disk_state="uptodate",resource="1-single-0",role="Secondary",volume="0"} 1 1234

--- a/test/drbd.metrics
+++ b/test/drbd.metrics
@@ -49,7 +49,7 @@ ha_cluster_drbd_lower_pending{resource="1-single-1",volume="0"} 2 1234
 # HELP ha_cluster_drbd_quorum Quorum status; 1 line per res, per volume
 # TYPE ha_cluster_drbd_quorum gauge
 ha_cluster_drbd_quorum{resource="1-single-0",volume="0"} 1 1234
-ha_cluster_drbd_quorum{resource="1-single-1",volume="0"} 1 1234
+ha_cluster_drbd_quorum{resource="1-single-1",volume="0"} 0 1234
 # HELP ha_cluster_drbd_resources The DRBD resources; 1 line per name, per volume
 # TYPE ha_cluster_drbd_resources gauge
 ha_cluster_drbd_resources{disk_state="uptodate",resource="1-single-0",role="Secondary",volume="0"} 1 1234

--- a/test/drbd.metrics
+++ b/test/drbd.metrics
@@ -46,7 +46,7 @@ ha_cluster_drbd_upper_pending{resource="1-single-1",volume="0"} 1 1234
 # TYPE ha_cluster_drbd_lower_pending gauge
 ha_cluster_drbd_lower_pending{resource="1-single-0",volume="0"} 2 1234
 ha_cluster_drbd_lower_pending{resource="1-single-1",volume="0"} 2 1234
-# HELP ha_cluster_drbd_quorum Quorum status; 1 line per res, per volume
+# HELP ha_cluster_drbd_quorum Quorum status per resource and per volume
 # TYPE ha_cluster_drbd_quorum gauge
 ha_cluster_drbd_quorum{resource="1-single-0",volume="0"} 1 1234
 ha_cluster_drbd_quorum{resource="1-single-1",volume="0"} 0 1234

--- a/test/fake_drbdsetup.sh
+++ b/test/fake_drbdsetup.sh
@@ -65,7 +65,7 @@ cat <<EOF
         "minor": 3,
         "disk-state": "UpToDate",
         "client": false,
-        "quorum": true,
+        "quorum": false,
         "size": 10200,
         "read": 654321,
         "written": 123456,


### PR DESCRIPTION
Hello Again!

I wanted to quickly add one more DRBD metric, quorum status, to the exporter. Sorry for not including it in the last PR.

drbd_metrics.go: Added quorum boolean to metrics.
drbd_metrics_test.go: Added test for quorum boolean and added some
  missing tests (missing from PR#106) for second resource.
test/drbd.metrics: added appropriate test values for new metric.
doc/metric_spec.md: added documentation for new metric.