### PR TITLE
Remove unrelevant warning for splitbrain file

### DIFF
--- a/drbd_metrics.go
+++ b/drbd_metrics.go
@@ -173,11 +173,9 @@ func (c *drbdCollector) setDrbdSplitBrainMetric(ch chan<- prometheus.Metric) {
 
 	// set split brain metric
 	// by default if the custom hook is not set, the exporter will not be able to detect it
-	files, err := ioutil.ReadDir(c.drbdSplitBrainPath)
-	if err != nil {
-		log.Warnf("Error while reading directory %s: %s", c.drbdSplitBrainPath, err)
-	}
+	files, _ := ioutil.ReadDir(c.drbdSplitBrainPath)
 
+	// the split brain files exists
 	for _, f := range files {
 		// check if in directory there are file of syntax we expect (nil is when there is not any)
 		match, _ := filepath.Glob(c.drbdSplitBrainPath + "/drbd-split-brain-detected-*")

--- a/test/drbd.metrics
+++ b/test/drbd.metrics
@@ -1,35 +1,3 @@
-# HELP ha_cluster_drbd_connections The DRBD resource connections; 1 line per per resource, per peer_node_id
-# TYPE ha_cluster_drbd_connections gauge
-ha_cluster_drbd_connections{peer_disk_state="uptodate",peer_node_id="1",peer_role="Primary",resource="1-single-0",volume="0"} 1 1234
-ha_cluster_drbd_connections{peer_disk_state="uptodate",peer_node_id="1",peer_role="Primary",resource="1-single-1",volume="0"} 1 1234
-# HELP ha_cluster_drbd_connections_sync The in sync percentage value for DRBD resource connections
-# TYPE ha_cluster_drbd_connections_sync gauge
-ha_cluster_drbd_connections_sync{peer_node_id="1",resource="1-single-0",volume="0"} 100 1234
-ha_cluster_drbd_connections_sync{peer_node_id="1",resource="1-single-1",volume="0"} 100 1234
-# HELP ha_cluster_drbd_connections_received KiB received per connection
-# TYPE ha_cluster_drbd_connections_received gauge
-ha_cluster_drbd_connections_received{peer_node_id="1",resource="1-single-0",volume="0"} 456 1234
-ha_cluster_drbd_connections_received{peer_node_id="1",resource="1-single-1",volume="0"} 456 1234
-# HELP ha_cluster_drbd_connections_sent KiB sent per connection
-# TYPE ha_cluster_drbd_connections_sent gauge
-ha_cluster_drbd_connections_sent{peer_node_id="1",resource="1-single-0",volume="0"} 654 1234
-ha_cluster_drbd_connections_sent{peer_node_id="1",resource="1-single-1",volume="0"} 654 1234
-# HELP ha_cluster_drbd_connections_pending Pending value per connection
-# TYPE ha_cluster_drbd_connections_pending gauge
-ha_cluster_drbd_connections_pending{peer_node_id="1",resource="1-single-0",volume="0"} 3 1234
-ha_cluster_drbd_connections_pending{peer_node_id="1",resource="1-single-1",volume="0"} 3 1234
-# HELP ha_cluster_drbd_connections_unacked Unacked value per connection
-# TYPE ha_cluster_drbd_connections_unacked gauge
-ha_cluster_drbd_connections_unacked{peer_node_id="1",resource="1-single-0",volume="0"} 4 1234
-ha_cluster_drbd_connections_unacked{peer_node_id="1",resource="1-single-1",volume="0"} 4 1234
-# HELP ha_cluster_drbd_written KiB written to DRBD; 1 line per res, per volume
-# TYPE ha_cluster_drbd_written gauge
-ha_cluster_drbd_written{resource="1-single-0",volume="0"} 123456 1234
-ha_cluster_drbd_written{resource="1-single-1",volume="0"} 123456 1234
-# HELP ha_cluster_drbd_read KiB read from DRBD; 1 line per res, per volume
-# TYPE ha_cluster_drbd_read gauge
-ha_cluster_drbd_read{resource="1-single-0",volume="0"} 654321 1234
-ha_cluster_drbd_read{resource="1-single-1",volume="0"} 654321 1234
 # HELP ha_cluster_drbd_al_writes Writes to activity log; 1 line per res, per volume
 # TYPE ha_cluster_drbd_al_writes gauge
 ha_cluster_drbd_al_writes{resource="1-single-0",volume="0"} 123 1234
@@ -38,10 +6,30 @@ ha_cluster_drbd_al_writes{resource="1-single-1",volume="0"} 123 1234
 # TYPE ha_cluster_drbd_bm_writes gauge
 ha_cluster_drbd_bm_writes{resource="1-single-0",volume="0"} 321 1234
 ha_cluster_drbd_bm_writes{resource="1-single-1",volume="0"} 321 1234
-# HELP ha_cluster_drbd_upper_pending Upper pending; 1 line per res, per volume
-# TYPE ha_cluster_drbd_upper_pending gauge
-ha_cluster_drbd_upper_pending{resource="1-single-0",volume="0"} 1 1234
-ha_cluster_drbd_upper_pending{resource="1-single-1",volume="0"} 1 1234
+# HELP ha_cluster_drbd_connections The DRBD resource connections; 1 line per per resource, per peer_node_id
+# TYPE ha_cluster_drbd_connections gauge
+ha_cluster_drbd_connections{peer_disk_state="uptodate",peer_node_id="1",peer_role="Primary",resource="1-single-0",volume="0"} 1 1234
+ha_cluster_drbd_connections{peer_disk_state="uptodate",peer_node_id="1",peer_role="Primary",resource="1-single-1",volume="0"} 1 1234
+# HELP ha_cluster_drbd_connections_pending Pending value per connection
+# TYPE ha_cluster_drbd_connections_pending gauge
+ha_cluster_drbd_connections_pending{peer_node_id="1",resource="1-single-0",volume="0"} 3 1234
+ha_cluster_drbd_connections_pending{peer_node_id="1",resource="1-single-1",volume="0"} 3 1234
+# HELP ha_cluster_drbd_connections_received KiB received per connection
+# TYPE ha_cluster_drbd_connections_received gauge
+ha_cluster_drbd_connections_received{peer_node_id="1",resource="1-single-0",volume="0"} 456 1234
+ha_cluster_drbd_connections_received{peer_node_id="1",resource="1-single-1",volume="0"} 456 1234
+# HELP ha_cluster_drbd_connections_sent KiB sent per connection
+# TYPE ha_cluster_drbd_connections_sent gauge
+ha_cluster_drbd_connections_sent{peer_node_id="1",resource="1-single-0",volume="0"} 654 1234
+ha_cluster_drbd_connections_sent{peer_node_id="1",resource="1-single-1",volume="0"} 654 1234
+# HELP ha_cluster_drbd_connections_sync The in sync percentage value for DRBD resource connections
+# TYPE ha_cluster_drbd_connections_sync gauge
+ha_cluster_drbd_connections_sync{peer_node_id="1",resource="1-single-0",volume="0"} 100 1234
+ha_cluster_drbd_connections_sync{peer_node_id="1",resource="1-single-1",volume="0"} 100 1234
+# HELP ha_cluster_drbd_connections_unacked Unacked value per connection
+# TYPE ha_cluster_drbd_connections_unacked gauge
+ha_cluster_drbd_connections_unacked{peer_node_id="1",resource="1-single-0",volume="0"} 4 1234
+ha_cluster_drbd_connections_unacked{peer_node_id="1",resource="1-single-1",volume="0"} 4 1234
 # HELP ha_cluster_drbd_lower_pending Lower pending; 1 line per res, per volume
 # TYPE ha_cluster_drbd_lower_pending gauge
 ha_cluster_drbd_lower_pending{resource="1-single-0",volume="0"} 2 1234
@@ -50,11 +38,19 @@ ha_cluster_drbd_lower_pending{resource="1-single-1",volume="0"} 2 1234
 # TYPE ha_cluster_drbd_quorum gauge
 ha_cluster_drbd_quorum{resource="1-single-0",volume="0"} 1 1234
 ha_cluster_drbd_quorum{resource="1-single-1",volume="0"} 0 1234
+# HELP ha_cluster_drbd_read KiB read from DRBD; 1 line per res, per volume
+# TYPE ha_cluster_drbd_read gauge
+ha_cluster_drbd_read{resource="1-single-0",volume="0"} 654321 1234
+ha_cluster_drbd_read{resource="1-single-1",volume="0"} 654321 1234
 # HELP ha_cluster_drbd_resources The DRBD resources; 1 line per name, per volume
 # TYPE ha_cluster_drbd_resources gauge
 ha_cluster_drbd_resources{disk_state="uptodate",resource="1-single-0",role="Secondary",volume="0"} 1 1234
 ha_cluster_drbd_resources{disk_state="uptodate",resource="1-single-1",role="Secondary",volume="0"} 1 1234
-# HELP ha_cluster_drbd_split_brain Whether a split brain has been detected; 1 line per resource, per volume.
-# TYPE ha_cluster_drbd_split_brain gauge
-ha_cluster_drbd_split_brain{resource="resource01",volume="vol01"} 1 1234
-ha_cluster_drbd_split_brain{resource="resource02",volume="vol02"} 1 1234
+# HELP ha_cluster_drbd_upper_pending Upper pending; 1 line per res, per volume
+# TYPE ha_cluster_drbd_upper_pending gauge
+ha_cluster_drbd_upper_pending{resource="1-single-0",volume="0"} 1 1234
+ha_cluster_drbd_upper_pending{resource="1-single-1",volume="0"} 1 1234
+# HELP ha_cluster_drbd_written KiB written to DRBD; 1 line per res, per volume
+# TYPE ha_cluster_drbd_written gauge
+ha_cluster_drbd_written{resource="1-single-0",volume="0"} 123456 1234
+ha_cluster_drbd_written{resource="1-single-1",volume="0"} 123456 1234


### PR DESCRIPTION
# What does this PR:

this fix #107 

On the otherside, this PR has the minimalist approach. 

I have been thought a while if we should report the existence of the file with a warn. But I think we can skip it. Because a part of the technical complexity (not major but kind of) to create a singleton object on the loop iteration (if we don't do it we will polluate logs with all this entry),

I think we can avoid to create the entry, since the user should know that if the exporter say that the metric is set to 1, he should remove the file. this is something we say also explitely on the metric usage and doc.
