### PR TITLE
reuse go pkg cache from build phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
           tags: true
       after_deploy:
         - |
-          docker run --rm -t -v "$(pwd):/package" -w /package \
+          docker run --rm -t -v "$(pwd):/package" -v "$GOPATH/pkg/mod:/root/go/pkg/mod" -w /package \
           -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG \
           shap/continuous_deliver \
           bash -c ".ci/init_osc_creds.sh && make obs-commit"


### PR DESCRIPTION
The Go mod cache was not being mounted in the Docker container, so the preparation of the obs workdir would always redownload all the modules.

A test CI run was produced here: https://travis-ci.org/stefanotorresi/ha_cluster_exporter/jobs/627191506