### PR TITLE
Include test files in release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,2 @@
 /.* export-ignore
-/test export-ignore
-*_test.go export-ignore
 /ha_cluster_exporter.spec export-ignore


### PR DESCRIPTION
Debian packaging of the exporter uses release .tar.gz files and it would be good to run tests.