### PR TITLE
Change default port from 9002 to 9964

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ You can run the exporter in any of the cluster nodes.
 
 ```
 $ ./ha_cluster_exporter  
-INFO[0000] Serving metrics on 0.0.0.0:9002
+INFO[0000] Serving metrics on 0.0.0.0:9964
 ```
 
 Though not strictly required, it is _strongly_ advised to run it in all the nodes.
 
-It will export the metrics under the `/metrics` path, on port `9002` by default.
+It will export the metrics under the `/metrics` path, on port `9964` by default.
 
 While the exporter can run outside a HA cluster node, it won't export any metric it can't collect; e.g. it won't export DRBD metrics if it can't be locally inspected with `drbdsetup`.  
 A warning message will inform the user of such cases.

--- a/ha_cluster_exporter.go
+++ b/ha_cluster_exporter.go
@@ -126,7 +126,7 @@ func init() {
 	config.AddConfigPath("/etc/")
 	config.AddConfigPath("/usr/etc/")
 
-	flag.String("port", "9002", "The port number to listen on for HTTP requests")
+	flag.String("port", "9964", "The port number to listen on for HTTP requests")
 	flag.String("address", "0.0.0.0", "The address to listen on for HTTP requests")
 	flag.String("log-level", "info", "The minimum logging level; levels are, in ascending order: debug, info, warn, error")
 	flag.String("crm-mon-path", "/usr/sbin/crm_mon", "path to crm_mon executable")

--- a/ha_cluster_exporter.yaml
+++ b/ha_cluster_exporter.yaml
@@ -1,5 +1,5 @@
 # sample config
-port: "9002"
+port: "9964"
 addres: "0.0.0.0"
 log-level: "info"
 crm-mon-path: "/usr/sbin/crm_mon"


### PR DESCRIPTION
This change is registered on https://github.com/prometheus/prometheus/wiki/Default-port-allocations
to be more inline with upstream