### PR TITLE
Minor CI fixes

### DIFF
--- a/.ci/gh_release_to_obs_changeset.py
+++ b/.ci/gh_release_to_obs_changeset.py
@@ -55,7 +55,7 @@ with tempfile.TemporaryFile("r+") as temp:
     temp.seek(0)
 
     if args.file:
-        with open(args.file, "r") as prev:
+        with open(args.file, "a+") as prev:
             old = prev.read()
         with open(args.file, "w") as new:
             for line in temp:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ jobs:
           docker run --rm -t -v "$(pwd):/package" -v "$GOPATH/pkg/mod:/root/go/pkg/mod" -w /package \
           -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG \
           shap/continuous_deliver \
-          bash -c "/scripts/init_osc_creds.sh && make obs-commit"
+          bash -c "/scripts/init_osc_creds.sh && make obs-commit" || travis_terminate 1

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ clean-obs:
 obs-workdir: build/obs
 build/obs:
 	osc checkout $(OBS_PROJECT)/$(OBS_PACKAGE) -o build/obs
-	rm build/obs/*.tar.gz
+	rm -f build/obs/*.tar.gz
 	cp -rv .ci/obs/* build/obs/
 	sed -i 's/%%VERSION%%/$(VERSION)/' build/obs/_service
 	cd build/obs; osc service runall


### PR DESCRIPTION
There were 2 bugs in the CI setup:
1. In the `make obs-workdir` target, the `rm` command that cleans up existing archives could fail if no archive were present in the obs source tree. Adding a `-f` flag fixes this.
2. The build would not fail if the OBS deployment Docker command fails. To fix this, I used the suggestion from travis-ci/travis-ci#1574.
3. The python script converting GitHub releases to RPM changelogs would not create a changelog file if none was present.