### PR TITLE
properly fix the changelog generator

### DIFF
--- a/.ci/gh_release_to_obs_changeset.py
+++ b/.ci/gh_release_to_obs_changeset.py
@@ -55,8 +55,11 @@ with tempfile.TemporaryFile("r+") as temp:
     temp.seek(0)
 
     if args.file:
-        with open(args.file, "a+") as prev:
-            old = prev.read()
+        try:
+            with open(args.file, "r") as prev:
+                old = prev.read()
+        except FileNotFoundError:
+            old = ""
         with open(args.file, "w") as new:
             for line in temp:
                 new.write(line)


### PR DESCRIPTION
#135 introduced a regression causing the old changelog entries not being preserved between OBS commits.