### PR TITLE
make RingID parsing compatible with corosync-quorumtool on Corosync v2.3.6

### DIFF
--- a/collector/corosync/parser.go
+++ b/collector/corosync/parser.go
@@ -103,11 +103,11 @@ func parseRingId(quorumToolOutput []byte) (string, error) {
 		Node ID:          1084780051
 		Ring ID:          1084780051.44
 		Quorate:          Yes
-	 */
+	*/
 	// in corosync < v2.99 the line is slightly different:
 	/*
 		Ring ID:          1084780051/44
-	 */
+	*/
 	// in corosync < v2.4 there is no representative node id:
 	/*
 		Ring ID:          1084780051

--- a/test/corosync.metrics
+++ b/test/corosync.metrics
@@ -12,8 +12,8 @@ ha_cluster_corosync_quorum_votes{type="total_votes"} 2
 ha_cluster_corosync_ring_errors 1
 # HELP ha_cluster_corosync_rings The status of each Corosync ring; 1 means healthy, 0 means faulty.
 # TYPE ha_cluster_corosync_rings gauge
-ha_cluster_corosync_rings{address="10.0.0.1",node_id="1084783375",number="0",ring_id="1084783375"} 0
-ha_cluster_corosync_rings{address="172.16.0.1",node_id="1084783375",number="1",ring_id="1084783375"} 1
+ha_cluster_corosync_rings{address="10.0.0.1",node_id="1084783375",number="0",ring_id="1084783375/40"} 0
+ha_cluster_corosync_rings{address="172.16.0.1",node_id="1084783375",number="1",ring_id="1084783375/40"} 1
 # HELP ha_cluster_corosync_member_votes How many votes each member node has contributed with to the current quorum
 # TYPE ha_cluster_corosync_member_votes gauge
 ha_cluster_corosync_member_votes{local="true",node="stefanotorresi-hana01",node_id="1084783375"} 1


### PR DESCRIPTION
We've been made aware of this incompatibility by MSFT who are running SLE12SP5, which runs an older version of Corosync we never tested against.

The format of the Ring ID changed in v2.4.0:
https://github.com/corosync/corosync/commit/434aa4fc6492b18d72975a8207e49d447d4ea7eb

We now parse the whole field as a string instead of trying to be too granular.