### PR TITLE
version CLI flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # this is the what ends up in the RPM "Version" field and it is also used as suffix for the built binaries
 # if you want to commit to OBS it must be a remotely available Git reference
-VERSION ?= $(shell git rev-parse --short HEAD)
+VERSION ?= $(shell git describe --tags --abbrev=0)dev+git.$(shell git show -s --format=%ct.%h HEAD)
+DATE = $(shell date --iso-8601=seconds)
 
 # we only use this to comply with RPM changelog conventions at SUSE
 AUTHOR ?= shap-staff@suse.de
@@ -25,7 +26,7 @@ build-all: clean-bin $(ARCHS)
 
 $(ARCHS):
 	@mkdir -p build/bin
-	CGO_ENABLED=0 GOOS=linux GOARCH=$@ go build -trimpath -ldflags "-s -w -X main.version=$(VERSION)" -o build/bin/ha_cluster_exporter-$(VERSION)-$@
+	CGO_ENABLED=0 GOOS=linux GOARCH=$@ go build -trimpath -ldflags "-s -w -X main.version=$(VERSION) -X main.buildDate=$(DATE)" -o build/bin/ha_cluster_exporter-$(VERSION)-$@
 
 install:
 	go install

--- a/ha_cluster_exporter.go
+++ b/ha_cluster_exporter.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"runtime"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -15,6 +17,13 @@ import (
 	"github.com/ClusterLabs/ha_cluster_exporter/collector/pacemaker"
 	"github.com/ClusterLabs/ha_cluster_exporter/collector/sbd"
 	"github.com/ClusterLabs/ha_cluster_exporter/internal"
+)
+
+var (
+	// The released version
+	version string
+	// The time the binary was built
+	buildDate string
 )
 
 func init() {
@@ -45,6 +54,10 @@ func init() {
 
 func main() {
 	var err error
+
+	if len(os.Args) > 1 && os.Args[1] == "version" {
+		handleVersionCommand()
+	}
 
 	flag.Parse()
 
@@ -111,4 +124,12 @@ func main() {
 
 	log.Infof("Serving metrics on %s", fullListenAddress)
 	log.Fatal(http.ListenAndServe(fullListenAddress, nil))
+}
+
+func handleVersionCommand() {
+	if buildDate == "" {
+		buildDate = "at unknown time"
+	}
+	fmt.Printf("ha_cluster_exporter %s\nbuilt with %s %s/%s %s\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH, buildDate)
+	os.Exit(0)
 }

--- a/ha_cluster_exporter.go
+++ b/ha_cluster_exporter.go
@@ -49,6 +49,7 @@ func init() {
 	flag.String("drbdsetup-path", "/sbin/drbdsetup", "path to drbdsetup executable")
 	flag.String("drbdsplitbrain-path", "/var/run/drbd/splitbrain", "path to drbd splitbrain hooks temporary files")
 	flag.Bool("enable-timestamps", false, "Add the timestamp to every metric line")
+	flag.CommandLine.MarkDeprecated("enable-timestamps", "server-side metric timestamping is discouraged by Prometheus best-practices and should be avoided")
 	flag.CommandLine.SortFlags = false
 
 	err := config.BindPFlags(flag.CommandLine)

--- a/packaging/obs/prometheus-ha_cluster_exporter.spec
+++ b/packaging/obs/prometheus-ha_cluster_exporter.spec
@@ -44,12 +44,13 @@ Prometheus exporter for Pacemaker HA clusters metrics
 %setup -q -T -D -a 1 # unpack go dependencies in vendor.tar.gz, which was prepared by the source services
 
 %define shortname ha_cluster_exporter
+%define build_date %(date --iso-8601=seconds)
 
 %build
 
 export CGO_ENABLED=0
 go build -mod=vendor \
-         -ldflags="-s -w -X main.version=%{version}" \
+         -ldflags="-s -w -X main.version=%{version} -X main.buildDate=%{build_date}" \
          -o %{shortname}
 
 %install


### PR DESCRIPTION
This PR adds a `--version` CLI flags that shows the version and build time embedded in the binary via ldflags.

It also deprecates the `--enable-timestamp`: it's still usable, but no longer advertised in the help message, and using it will issue a warning message on startup.

Furthermore, invoking the `--help` flag will no longer exit with a non-0 code.