### PR TITLE
Add qdevice membership parsing and metric label

### DIFF
--- a/collector/corosync/corosync.go
+++ b/collector/corosync/corosync.go
@@ -27,7 +27,7 @@ func NewCollector(cfgToolPath string, quorumToolPath string) (*corosyncCollector
 	c.SetDescriptor("quorate", "Whether or not the cluster is quorate", nil)
 	c.SetDescriptor("rings", "The status of each Corosync ring; 1 means healthy, 0 means faulty.", []string{"ring_id", "node_id", "number", "address"})
 	c.SetDescriptor("ring_errors", "The total number of faulty corosync rings", nil)
-	c.SetDescriptor("member_votes", "How many votes each member node has contributed with to the current quorum", []string{"node_id", "qdevice", "node", "local"})
+	c.SetDescriptor("member_votes", "How many votes each member node has contributed with to the current quorum", []string{"node_id", "node", "local"})
 	c.SetDescriptor("quorum_votes", "Cluster quorum votes; one line per type", []string{"type"})
 
 	return c, nil
@@ -109,6 +109,6 @@ func (c *corosyncCollector) collectMemberVotes(status *Status, ch chan<- prometh
 		if member.Local {
 			local = "true"
 		}
-		ch <- c.MakeGaugeMetric("member_votes", float64(member.Votes), member.Id, member.Qdevice, member.Name, local)
+		ch <- c.MakeGaugeMetric("member_votes", float64(member.Votes), member.Id, member.Name, local)
 	}
 }

--- a/collector/corosync/corosync.go
+++ b/collector/corosync/corosync.go
@@ -27,7 +27,7 @@ func NewCollector(cfgToolPath string, quorumToolPath string) (*corosyncCollector
 	c.SetDescriptor("quorate", "Whether or not the cluster is quorate", nil)
 	c.SetDescriptor("rings", "The status of each Corosync ring; 1 means healthy, 0 means faulty.", []string{"ring_id", "node_id", "number", "address"})
 	c.SetDescriptor("ring_errors", "The total number of faulty corosync rings", nil)
-	c.SetDescriptor("member_votes", "How many votes each member node has contributed with to the current quorum", []string{"node_id", "node", "local"})
+	c.SetDescriptor("member_votes", "How many votes each member node has contributed with to the current quorum", []string{"node_id", "qdevice", "node", "local"})
 	c.SetDescriptor("quorum_votes", "Cluster quorum votes; one line per type", []string{"type"})
 
 	return c, nil
@@ -45,7 +45,7 @@ func (c *corosyncCollector) CollectWithError(ch chan<- prometheus.Metric) error 
 
 	// We suppress the exec errors because if any interface is faulty the tools will exit with code 1, but we still want to parse the output.
 	cfgToolOutput, _ := exec.Command(c.cfgToolPath, "-s").Output()
-	quorumToolOutput, _ := exec.Command(c.quorumToolPath).Output()
+	quorumToolOutput, _ := exec.Command(c.quorumToolPath, "-p").Output()
 
 	status, err := c.parser.Parse(cfgToolOutput, quorumToolOutput)
 	if err != nil {
@@ -109,6 +109,6 @@ func (c *corosyncCollector) collectMemberVotes(status *Status, ch chan<- prometh
 		if member.Local {
 			local = "true"
 		}
-		ch <- c.MakeGaugeMetric("member_votes", float64(member.Votes), member.Id, member.Name, local)
+		ch <- c.MakeGaugeMetric("member_votes", float64(member.Votes), member.Id, member.Qdevice, member.Name, local)
 	}
 }

--- a/collector/corosync/parser.go
+++ b/collector/corosync/parser.go
@@ -227,7 +227,7 @@ func parseMembers(quorumToolOutput []byte) (members []Member, err error) {
 	/*
 		1          1  A,V,NMW 192.168.125.24 (local)
 	*/
-	linesRE := regexp.MustCompile(`(?m)(?P<node_id>\w+)\s+(?P<votes>\d+)\s+(?P<qdevice>(\w,?)+)\s+(?P<name>[\w-\.]+)(?:\s(?P<local>\(local\)))?\n?`)
+	linesRE := regexp.MustCompile(`(?m)(?P<node_id>\w+)\s+(?P<votes>\d+)\s+(?P<qdevice>(\w,?)+)?\s+(?P<name>[\w-\.]+)(?:\s(?P<local>\(local\)))?\n?`)
 	linesMatches := linesRE.FindAllSubmatch(sectionMatch[1], -1)
 	for _, match := range linesMatches {
 		matches := extractRENamedCaptureGroups(linesRE, match)

--- a/collector/corosync/parser.go
+++ b/collector/corosync/parser.go
@@ -35,10 +35,11 @@ type Ring struct {
 }
 
 type Member struct {
-	Id    string
-	Name  string
-	Votes uint64
-	Local bool
+	Id      string
+	Name    string
+	Qdevice string
+	Votes   uint64
+	Local   bool
 }
 
 func NewParser() Parser {
@@ -211,11 +212,12 @@ func parseMembers(quorumToolOutput []byte) (members []Member, err error) {
 	/*
 	   Membership information
 	   ----------------------
-	      Nodeid      Votes Name
-	   		1          1 192.168.125.24
-	   		2          1 192.168.125.25 (local)
+	   Nodeid      Votes    Qdevice Name
+	        1          1    A,V,NMW nfs01 (local)
+	        2          1    A,V,NMW nfs02
+	        0          1            Qdevice
 	*/
-	sectionRE := regexp.MustCompile(`(?m)Membership information\n-+\s+Nodeid\s+Votes\s+Name\n+((?:.*\n?)+)`)
+	sectionRE := regexp.MustCompile(`(?m)Membership information\n-+\s+Nodeid\s+Votes\s+Qdevice\s+Name\n+((?:.*\n?)+)`)
 	sectionMatch := sectionRE.FindSubmatch(quorumToolOutput)
 	if sectionMatch == nil {
 		return nil, errors.New("could not find membership information")
@@ -223,9 +225,9 @@ func parseMembers(quorumToolOutput []byte) (members []Member, err error) {
 
 	// we also need a second regex to capture the single elements of each node line, e.g.:
 	/*
-		1          1 192.168.125.24 (local)
+		1          1  A,V,NMW 192.168.125.24 (local)
 	*/
-	linesRE := regexp.MustCompile(`(?m)(?P<node_id>\w+)\s+(?P<votes>\d+)\s(?P<name>[\w-\.]+)(?:\s(?P<local>\(local\)))?\n?`)
+	linesRE := regexp.MustCompile(`(?m)(?P<node_id>\w+)\s+(?P<votes>\d+)\s+(?P<qdevice>(\w,?)+)\s+(?P<name>[\w-\.]+)(?:\s(?P<local>\(local\)))?\n?`)
 	linesMatches := linesRE.FindAllSubmatch(sectionMatch[1], -1)
 	for _, match := range linesMatches {
 		matches := extractRENamedCaptureGroups(linesRE, match)
@@ -241,10 +243,11 @@ func parseMembers(quorumToolOutput []byte) (members []Member, err error) {
 		}
 
 		members = append(members, Member{
-			Id:    matches["node_id"],
-			Name:  matches["name"],
-			Votes: votes,
-			Local: local,
+			Id:      matches["node_id"],
+			Name:    matches["name"],
+			Votes:   votes,
+			Local:   local,
+			Qdevice: matches["qdevice"],
 		})
 	}
 

--- a/collector/corosync/parser_test.go
+++ b/collector/corosync/parser_test.go
@@ -38,9 +38,9 @@ Flags:            2Node Quorate WaitForAll
 
 Membership information
 ----------------------
-	Nodeid      Votes Name
-1084780051          1 dma-dog-hana01 (local)
-1084780052          1 dma-dog-hana02`)
+	Nodeid      Votes Qdevice Name
+1084780051          1      NR dma-dog-hana01 (local)
+1084780052          1      A,V,NMW dma-dog-hana02`)
 
 	status, err := p.Parse(cfgToolOutput, quoromToolOutput)
 	assert.NoError(t, err)
@@ -67,10 +67,12 @@ Membership information
 	assert.Len(t, members, 2)
 	assert.Exactly(t, "1084780051", members[0].Id)
 	assert.Exactly(t, "dma-dog-hana01", members[0].Name)
+	assert.Exactly(t, "NR", members[0].Qdevice)
 	assert.True(t, members[0].Local)
 	assert.EqualValues(t, 1, members[0].Votes)
 	assert.Exactly(t, "1084780052", members[1].Id)
 	assert.Exactly(t, "dma-dog-hana02", members[1].Name)
+	assert.Exactly(t, "A,V,NMW", members[1].Qdevice)
 	assert.False(t, members[1].Local)
 	assert.EqualValues(t, 1, members[1].Votes)
 }
@@ -250,8 +252,8 @@ func TestParseMembersEmptyError(t *testing.T) {
 func TestParseMembersUintError(t *testing.T) {
 	quoromToolOutput := []byte(`Membership information
 ----------------------
-	Nodeid      Votes Name
-1084780051 10000000000000000000000000000000000000000000000 dma-dog-hana01`)
+    Nodeid      Votes Qdevice Name
+1084780051 10000000000000000000000000000000000000000000000 NW dma-dog-hana01`)
 
 	_, err := parseMembers(quoromToolOutput)
 
@@ -280,9 +282,9 @@ Flags:            2Node Quorate WaitForAll
 
 Membership information
 ----------------------
-    Nodeid      Votes Name
-         1          1 192.168.127.20
-         2          1 192.168.127.21 (local)`)
+    Nodeid      Votes Qdevice Name
+         1          1      NR  192.168.127.20
+         2          1      NR  192.168.127.21 (local)`)
 
 	members, err := parseMembers(quorumToolOutput)
 

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -150,9 +150,6 @@ How many votes each member node has contributed with to the current quorum
 
 - `node_id`: the internal corosync identifier associated to this node.
 - `node`: the name of the node; usually the hostname.
-- `qdevice`: Shows the connectivity status between QDevice and Corosync.
-             Possible statuses: 
-   A (Alive) or NA (not alive), V (Vote) or NV (non vote), MW (Master wins) or NMW(not master wins), NR  not registered.
 - `local`: whether or not this is the local node.
 
 

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -150,6 +150,9 @@ How many votes each member node has contributed with to the current quorum
 
 - `node_id`: the internal corosync identifier associated to this node.
 - `node`: the name of the node; usually the hostname.
+- `qdevice`: Shows the connectivity status between QDevice and Corosync.
+             Possible statuses: 
+   A (Alive) or NA (not alive), V (Vote) or NV (non vote), MW (Master wins) or NMW(not master wins), NR  not registered.
 - `local`: whether or not this is the local node.
 
 

--- a/test/corosync.metrics
+++ b/test/corosync.metrics
@@ -1,5 +1,6 @@
 # HELP ha_cluster_corosync_member_votes How many votes each member node has contributed with to the current quorum
 # TYPE ha_cluster_corosync_member_votes gauge
+ha_cluster_corosync_member_votes{local="false",node="Qdevice",node_id="0",qdevice=""} 1
 ha_cluster_corosync_member_votes{local="false",node="stefanotorresi-hana02",node_id="1084783376",qdevice="A,V,NMW"} 1
 ha_cluster_corosync_member_votes{local="true",node="stefanotorresi-hana01",node_id="1084783375",qdevice="NR"} 1
 # HELP ha_cluster_corosync_quorate Whether or not the cluster is quorate

--- a/test/corosync.metrics
+++ b/test/corosync.metrics
@@ -1,8 +1,8 @@
 # HELP ha_cluster_corosync_member_votes How many votes each member node has contributed with to the current quorum
 # TYPE ha_cluster_corosync_member_votes gauge
-ha_cluster_corosync_member_votes{local="false",node="Qdevice",node_id="0",qdevice=""} 1
-ha_cluster_corosync_member_votes{local="false",node="stefanotorresi-hana02",node_id="1084783376",qdevice="A,V,NMW"} 1
-ha_cluster_corosync_member_votes{local="true",node="stefanotorresi-hana01",node_id="1084783375",qdevice="NR"} 1
+ha_cluster_corosync_member_votes{local="false",node="Qdevice",node_id="0"} 1
+ha_cluster_corosync_member_votes{local="false",node="stefanotorresi-hana02",node_id="1084783376"} 1
+ha_cluster_corosync_member_votes{local="true",node="stefanotorresi-hana01",node_id="1084783375"} 1
 # HELP ha_cluster_corosync_quorate Whether or not the cluster is quorate
 # TYPE ha_cluster_corosync_quorate gauge
 ha_cluster_corosync_quorate 1

--- a/test/corosync.metrics
+++ b/test/corosync.metrics
@@ -1,3 +1,7 @@
+# HELP ha_cluster_corosync_member_votes How many votes each member node has contributed with to the current quorum
+# TYPE ha_cluster_corosync_member_votes gauge
+ha_cluster_corosync_member_votes{local="false",node="stefanotorresi-hana02",node_id="1084783376",qdevice="A,V,NMW"} 1
+ha_cluster_corosync_member_votes{local="true",node="stefanotorresi-hana01",node_id="1084783375",qdevice="NR"} 1
 # HELP ha_cluster_corosync_quorate Whether or not the cluster is quorate
 # TYPE ha_cluster_corosync_quorate gauge
 ha_cluster_corosync_quorate 1
@@ -14,7 +18,3 @@ ha_cluster_corosync_ring_errors 1
 # TYPE ha_cluster_corosync_rings gauge
 ha_cluster_corosync_rings{address="10.0.0.1",node_id="1084783375",number="0",ring_id="1084783375/40"} 0
 ha_cluster_corosync_rings{address="172.16.0.1",node_id="1084783375",number="1",ring_id="1084783375/40"} 1
-# HELP ha_cluster_corosync_member_votes How many votes each member node has contributed with to the current quorum
-# TYPE ha_cluster_corosync_member_votes gauge
-ha_cluster_corosync_member_votes{local="true",node="stefanotorresi-hana01",node_id="1084783375"} 1
-ha_cluster_corosync_member_votes{local="false",node="stefanotorresi-hana02",node_id="1084783376"} 1

--- a/test/fake_corosync-quorumtool.sh
+++ b/test/fake_corosync-quorumtool.sh
@@ -20,7 +20,7 @@ Flags:            2Node Quorate
 
 Membership information
 ----------------------
-    Nodeid      Votes Name
-1084783375          1 stefanotorresi-hana01 (local)
-1084783376          1 stefanotorresi-hana02
+    Nodeid      Votes  Qdevice Name
+1084783375          1      NR  stefanotorresi-hana01 (local)
+1084783376          1  A,V,NMW stefanotorresi-hana02
 EOF

--- a/test/fake_corosync-quorumtool.sh
+++ b/test/fake_corosync-quorumtool.sh
@@ -23,4 +23,5 @@ Membership information
     Nodeid      Votes  Qdevice Name
 1084783375          1      NR  stefanotorresi-hana01 (local)
 1084783376          1  A,V,NMW stefanotorresi-hana02
+         0          1            Qdevice
 EOF


### PR DESCRIPTION
Fix #170 

There is only one special case, we might need to handle:

```ha_cluster_corosync_member_votes{local="false",node="Qdevice",node_id="0",qdevice=""} 1```

when the qdevice is active


```
Quorum information
------------------
Date:             Thu Jul 16 12:40:44 2020
Quorum provider:  corosync_votequorum
Nodes:            2
Node ID:          1
Ring ID:          1/139
Quorate:          Yes

Votequorum information
----------------------
Expected votes:   3
Highest expected: 3
Total votes:      3
Quorum:           2  
Flags:            Quorate Qdevice 

Membership information
----------------------
    Nodeid      Votes    Qdevice Name
         1          1    A,V,NMW nfs01 (local)
         2          1    A,V,NMW nfs02
         0          1            Qdevice
```

the table qdevice is empty so we create an empty metric.

I was thinking in order to avoid an empty metric we should populated the label `qdevice` with `qdevice` for indicating that it is the qdevice.

@gao-yan @nick-wang let me know what do you think