### PR TITLE
Implement SBD watchdog and msgwait metrics

### DIFF
--- a/collector/sbd/sbd.go
+++ b/collector/sbd/sbd.go
@@ -35,7 +35,7 @@ func NewCollector(sbdPath string, sbdConfigPath string) (*sbdCollector, error) {
 	}
 
 	c.SetDescriptor("devices", "SBD devices; one line per device", []string{"device", "status"})
-	c.SetDescriptor("sbd_timeout", "sbd watchdog timeout", []string{"device", "type"})
+	c.SetDescriptor("timeouts", "SBD timeouts for each device and type", []string{"device", "type"})
 
 	return c, nil
 }
@@ -73,11 +73,11 @@ func (c *sbdCollector) CollectWithError(ch chan<- prometheus.Metric) error {
 
 	sbdWatchdogs, sbdMsgWaits := c.getSbdTimeouts(sbdDevices)
 	for sbdDev, sbdWatchdog := range sbdWatchdogs {
-		ch <- c.MakeGaugeMetric("sbd_timeout", sbdWatchdog, sbdDev, "watchdog_timeout")
+		ch <- c.MakeGaugeMetric("timeouts", sbdWatchdog, sbdDev, "watchdog")
 	}
 
 	for sbdDev, sbdMsgWait := range sbdMsgWaits {
-		ch <- c.MakeGaugeMetric("sbd_timeout", sbdMsgWait, sbdDev, "msgwait_timeout")
+		ch <- c.MakeGaugeMetric("timeouts", sbdMsgWait, sbdDev, "msgwait")
 	}
 
 	return nil

--- a/collector/sbd/sbd.go
+++ b/collector/sbd/sbd.go
@@ -166,7 +166,7 @@ func (c *sbdCollector) getSbdWatchDogTimeout(sbdDevices []string) map[string]flo
 		if watchdogTimeout == nil {
 			continue
 		}
-
+		// map the timeout to the device
 		if s, err := strconv.ParseFloat(watchdogTimeout[0], 64); err == nil {
 			sbdWatchdogs[sbdDev] = s
 		}
@@ -181,7 +181,7 @@ func (c *sbdCollector) getSbdMsgWaitTimeout(sbdDevices []string) map[string]floa
 		sbdDump, _ := exec.Command(c.sbdPath, "-d", sbdDev, "dump").Output()
 
 		regex := regexp.MustCompile(`Timeout \(msgwait\)  *: \d+`)
-		// we get this line:		Timeout (watchdog) : 5
+		// we get this line:		Timeout (msgwait) : 5
 		msgWaitLine := regex.FindStringSubmatch(string(sbdDump))
 
 		if msgWaitLine == nil {
@@ -193,7 +193,7 @@ func (c *sbdCollector) getSbdMsgWaitTimeout(sbdDevices []string) map[string]floa
 		if msgWaitTimeout == nil {
 			continue
 		}
-
+		// map the timeout to the device
 		if s, err := strconv.ParseFloat(msgWaitTimeout[0], 64); err == nil {
 			sbdMsgWaits[sbdDev] = s
 		}

--- a/collector/sbd/sbd_test.go
+++ b/collector/sbd/sbd_test.go
@@ -214,6 +214,13 @@ func TestNewSbdCollectorChecksSbdExecutableBits(t *testing.T) {
 }
 
 func TestSBDCollector(t *testing.T) {
-	collector, _ := NewCollector("../../test/fake_sbd.sh", "../../test/fake_sbdconfig")
+	collector, _ := NewCollector("../../test/fake_sbd_dump.sh", "../../test/fake_sbdconfig")
+	assertcustom.Metrics(t, collector, "sbd.metrics")
+}
+
+func TestWatchdog(t *testing.T) {
+	collector, err := NewCollector("../../test/fake_sbd_dump.sh", "../../test/fake_sbdconfig")
+
+	assert.Nil(t, err)
 	assertcustom.Metrics(t, collector, "sbd.metrics")
 }

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -198,7 +198,8 @@ The status of each Corosync ring; `1` means healthy, `0` means faulty.
 The SBD subsystems collect devices stats by parsing its configuration and the output of `sbd --dump`.
 
 0. [Sample](../test/sbd.metrics)
-2. [`ha_cluster_sbd_devices`](#ha_cluster_sbd_devices)
+1. [`ha_cluster_sbd_devices`](#ha_cluster_sbd_devices)
+2. [`ha_cluster_sbd_timeouts`](#ha_cluster_sbd_timeouts)
 
 ### `ha_cluster_sbd_devices`
 
@@ -213,6 +214,18 @@ Either the value is `1`, or the line is absent altogether.
 - `status`: one of `healthy|unhealthy`
 
 The total number of lines for this metric will be the cardinality of `device`.
+
+### `ha_cluster_sbd_timeouts`
+
+#### Description
+
+The SBD timeouts pro SBD device
+Value is an integer expessing the timeout
+
+#### Labels
+
+- `device`: the path of the SBD device
+- `type`:  either `watchdog` or `msgwait`
 
 
 ## DRBD

--- a/test/fake_sbd_dump.sh
+++ b/test/fake_sbd_dump.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+cat <<EOF
+==Dumping header on disk /dev/vdc
+Header version     : 2.1
+UUID               : 1ed3171d-066d-47ca-8f76-aec25d9efed4
+Number of slots    : 255
+Sector size        : 512
+Timeout (watchdog) : 5
+Timeout (allocate) : 2
+Timeout (loop)     : 1
+Timeout (msgwait)  : 10
+==Header on disk /dev/vdc is dumped
+==Dumping header on disk /dev/vdc
+Header version     : 2.1
+UUID               : 1ed3171d-066d-47ca-8f76-aec25d9efed4
+Number of slots    : 255
+Sector size        : 512
+Timeout (watchdog) : 5
+Timeout (allocate) : 2
+Timeout (loop)     : 1
+Timeout (msgwait)  : 10
+==Header on disk /dev/vdc is dumped
+EOF

--- a/test/fake_sbd_dump.sh
+++ b/test/fake_sbd_dump.sh
@@ -6,17 +6,7 @@ Header version     : 2.1
 UUID               : 1ed3171d-066d-47ca-8f76-aec25d9efed4
 Number of slots    : 255
 Sector size        : 512
-Timeout (watchdog) : 5
-Timeout (allocate) : 2
-Timeout (loop)     : 1
-Timeout (msgwait)  : 10
-==Header on disk /dev/vdc is dumped
-==Dumping header on disk /dev/vdc
-Header version     : 2.1
-UUID               : 1ed3171d-066d-47ca-8f76-aec25d9efed4
-Number of slots    : 255
-Sector size        : 512
-Timeout (watchdog) : 5
+Timeout (watchdog) : 9
 Timeout (allocate) : 2
 Timeout (loop)     : 1
 Timeout (msgwait)  : 10

--- a/test/sbd.metrics
+++ b/test/sbd.metrics
@@ -2,9 +2,9 @@
 # TYPE ha_cluster_sbd_devices gauge
 ha_cluster_sbd_devices{device="/dev/vdc",status="healthy"} 1
 ha_cluster_sbd_devices{device="/dev/vdd",status="healthy"} 1
-# HELP ha_cluster_sbd_sbd_timeout sbd watchdog timeout
-# TYPE ha_cluster_sbd_sbd_timeout gauge
-ha_cluster_sbd_sbd_timeout{device="/dev/vdc",type="msgwait_timeout"} 10
-ha_cluster_sbd_sbd_timeout{device="/dev/vdc",type="watchdog_timeout"} 9
-ha_cluster_sbd_sbd_timeout{device="/dev/vdd",type="msgwait_timeout"} 10
-ha_cluster_sbd_sbd_timeout{device="/dev/vdd",type="watchdog_timeout"} 9
+# HELP ha_cluster_sbd_timeouts SBD timeouts for each device and type
+# TYPE ha_cluster_sbd_timeouts gauge
+ha_cluster_sbd_timeouts{device="/dev/vdc",type="msgwait"} 10
+ha_cluster_sbd_timeouts{device="/dev/vdc",type="watchdog"} 9
+ha_cluster_sbd_timeouts{device="/dev/vdd",type="msgwait"} 10
+ha_cluster_sbd_timeouts{device="/dev/vdd",type="watchdog"} 9

--- a/test/sbd.metrics
+++ b/test/sbd.metrics
@@ -1,4 +1,8 @@
 # HELP ha_cluster_sbd_devices SBD devices; one line per device
 # TYPE ha_cluster_sbd_devices gauge
 ha_cluster_sbd_devices{device="/dev/vdc",status="healthy"} 1
-ha_cluster_sbd_devices{device="/dev/vdd",status="unhealthy"} 1
+ha_cluster_sbd_devices{device="/dev/vdd",status="healthy"} 1
+# HELP ha_cluster_sbd_watchdog_timeout sbd watchdog timeout
+# TYPE ha_cluster_sbd_watchdog_timeout gauge
+ha_cluster_sbd_watchdog_timeout{device="/dev/vdc"} 9
+ha_cluster_sbd_watchdog_timeout{device="/dev/vdd"} 9

--- a/test/sbd.metrics
+++ b/test/sbd.metrics
@@ -1,12 +1,10 @@
- # HELP ha_cluster_sbd_devices SBD devices; one line per device
- # TYPE ha_cluster_sbd_devices gauge
- ha_cluster_sbd_devices{device="/dev/vdc",status="healthy"} 1
- ha_cluster_sbd_devices{device="/dev/vdd",status="healthy"} 1
- # HELP ha_cluster_sbd_msgwait_timeout sbd msgwait timeout
- # TYPE ha_cluster_sbd_msgwait_timeout gauge
- ha_cluster_sbd_msgwait_timeout{device="/dev/vdc"} 10
- ha_cluster_sbd_msgwait_timeout{device="/dev/vdd"} 10
- # HELP ha_cluster_sbd_watchdog_timeout sbd watchdog timeout
- # TYPE ha_cluster_sbd_watchdog_timeout gauge
- ha_cluster_sbd_watchdog_timeout{device="/dev/vdc"} 9
- ha_cluster_sbd_watchdog_timeout{device="/dev/vdd"} 9
+# HELP ha_cluster_sbd_devices SBD devices; one line per device
+# TYPE ha_cluster_sbd_devices gauge
+ha_cluster_sbd_devices{device="/dev/vdc",status="healthy"} 1
+ha_cluster_sbd_devices{device="/dev/vdd",status="healthy"} 1
+# HELP ha_cluster_sbd_sbd_timeout sbd watchdog timeout
+# TYPE ha_cluster_sbd_sbd_timeout gauge
+ha_cluster_sbd_sbd_timeout{device="/dev/vdc",type="msgwait_timeout"} 10
+ha_cluster_sbd_sbd_timeout{device="/dev/vdc",type="watchdog_timeout"} 9
+ha_cluster_sbd_sbd_timeout{device="/dev/vdd",type="msgwait_timeout"} 10
+ha_cluster_sbd_sbd_timeout{device="/dev/vdd",type="watchdog_timeout"} 9

--- a/test/sbd.metrics
+++ b/test/sbd.metrics
@@ -1,8 +1,12 @@
-# HELP ha_cluster_sbd_devices SBD devices; one line per device
-# TYPE ha_cluster_sbd_devices gauge
-ha_cluster_sbd_devices{device="/dev/vdc",status="healthy"} 1
-ha_cluster_sbd_devices{device="/dev/vdd",status="healthy"} 1
-# HELP ha_cluster_sbd_watchdog_timeout sbd watchdog timeout
-# TYPE ha_cluster_sbd_watchdog_timeout gauge
-ha_cluster_sbd_watchdog_timeout{device="/dev/vdc"} 9
-ha_cluster_sbd_watchdog_timeout{device="/dev/vdd"} 9
+ # HELP ha_cluster_sbd_devices SBD devices; one line per device
+ # TYPE ha_cluster_sbd_devices gauge
+ ha_cluster_sbd_devices{device="/dev/vdc",status="healthy"} 1
+ ha_cluster_sbd_devices{device="/dev/vdd",status="healthy"} 1
+ # HELP ha_cluster_sbd_msgwait_timeout sbd msgwait timeout
+ # TYPE ha_cluster_sbd_msgwait_timeout gauge
+ ha_cluster_sbd_msgwait_timeout{device="/dev/vdc"} 10
+ ha_cluster_sbd_msgwait_timeout{device="/dev/vdd"} 10
+ # HELP ha_cluster_sbd_watchdog_timeout sbd watchdog timeout
+ # TYPE ha_cluster_sbd_watchdog_timeout gauge
+ ha_cluster_sbd_watchdog_timeout{device="/dev/vdc"} 9
+ ha_cluster_sbd_watchdog_timeout{device="/dev/vdd"} 9


### PR DESCRIPTION
# todo:
- [x] add documentation for metrics

# Note:

I have implemented the metric  like 

```
ha_cluster_sbd_devices{device="/dev/vdd",status="healthy"} 1
ha_cluster_sbd_devices_watchdog_timeout{device="/dev/vdc"} 60
ha_cluster_sbd_devices_msgwait_timeout{device="/dev/vdd"} 120
```

I didn't found any useful doc about the `loop` and  `allocate` metric so I even wondered if we should expose them. (In fact I haven't but if they are meant to be useful, we should definitely document this in the suse-doc)
See:
https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/cha-ha-storage-protect.html#sec-ha-storage-protect-watchdog-timings

@diegoakechi cc
@nick-wang cc


I personally think that if we are exposing only 2 metrics we can create for each one a new metric without label.

If we want to expose 4 then I will refactor accordingly with a `type` label. I am ok with both directions
