### PR TITLE
remove explicit Pacemaker dependency from the systemd unit

### DIFF
--- a/ha_cluster_exporter.service
+++ b/ha_cluster_exporter.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Prometheus exporter for Pacemaker HA clusters metrics
-Wants=pacemaker.service
-After=network.target pacemaker.service
+After=network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
We don't actually need the Pacemaker service to be running, and we don't want to interact with it in case the system is rebooted (e.g. the Pacemaker service was temporarily disabled to do maintenance).