### PR TITLE
cib: expose crm_config as well

### DIFF
--- a/collector/pacemaker/cib/data.go
+++ b/collector/pacemaker/cib/data.go
@@ -10,6 +10,9 @@ https://clusterlabs.org/pacemaker/doc/en-US/Pacemaker/2.0/html-single/Pacemaker_
 
 type Root struct {
 	Configuration struct {
+		CrmConfig struct {
+			ClusterProperties []Attribute `xml:"cluster_property_set>nvpair"`
+		} `xml:"crm_config"`
 		Nodes []struct {
 			Id                 string      `xml:"id,attr"`
 			Uname              string      `xml:"uname,attr"`

--- a/collector/pacemaker/cib/parser_test.go
+++ b/collector/pacemaker/cib/parser_test.go
@@ -16,6 +16,8 @@ func TestParse(t *testing.T) {
 	data, err := p.Parse()
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(data.Configuration.Nodes))
+	assert.Equal(t, "cib-bootstrap-options-cluster-name", data.Configuration.CrmConfig.ClusterProperties[3].Id)
+	assert.Equal(t, "hana_cluster", data.Configuration.CrmConfig.ClusterProperties[3].Value)
 	assert.Equal(t, "node01", data.Configuration.Nodes[0].Uname)
 	assert.Equal(t, "node02", data.Configuration.Nodes[1].Uname)
 	assert.Equal(t, 4, len(data.Configuration.Resources.Primitives))


### PR DESCRIPTION
This allows, amongst other things, to access the
cib-bootstrap-options-cluster-name and stonith-enabled parameters