### PR TITLE
fix cloned resource collection once and for all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,7 @@ REPOSITORY ?= clusterlabs/ha_cluster_exporter
 # the Go archs we crosscompile to
 ARCHS ?= amd64 arm64 ppc64le s390x
 
-default: clean download mod-tidy generate fmt vet-check test build
-
-download:
-	go mod download
-	go mod verify
+default: clean mod-tidy generate fmt vet-check test build
 
 build: amd64
 
@@ -36,7 +32,7 @@ install:
 
 static-checks: vet-check fmt-check
 
-vet-check: download
+vet-check:
 	go vet ./...
 
 fmt:
@@ -51,7 +47,7 @@ fmt-check:
 generate:
 	go generate ./...
 
-test: download
+test:
 	go test -v ./...
 
 checks: static-checks test

--- a/test/mock_collector/instrumented_collector.go
+++ b/test/mock_collector/instrumented_collector.go
@@ -5,48 +5,47 @@
 package mock_collector
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	prometheus "github.com/prometheus/client_golang/prometheus"
+	reflect "reflect"
 )
 
-// MockInstrumentableCollector is a mock of InstrumentableCollector interface.
+// MockInstrumentableCollector is a mock of InstrumentableCollector interface
 type MockInstrumentableCollector struct {
 	ctrl     *gomock.Controller
 	recorder *MockInstrumentableCollectorMockRecorder
 }
 
-// MockInstrumentableCollectorMockRecorder is the mock recorder for MockInstrumentableCollector.
+// MockInstrumentableCollectorMockRecorder is the mock recorder for MockInstrumentableCollector
 type MockInstrumentableCollectorMockRecorder struct {
 	mock *MockInstrumentableCollector
 }
 
-// NewMockInstrumentableCollector creates a new mock instance.
+// NewMockInstrumentableCollector creates a new mock instance
 func NewMockInstrumentableCollector(ctrl *gomock.Controller) *MockInstrumentableCollector {
 	mock := &MockInstrumentableCollector{ctrl: ctrl}
 	mock.recorder = &MockInstrumentableCollectorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockInstrumentableCollector) EXPECT() *MockInstrumentableCollectorMockRecorder {
 	return m.recorder
 }
 
-// Collect mocks base method.
+// Collect mocks base method
 func (m *MockInstrumentableCollector) Collect(arg0 chan<- prometheus.Metric) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Collect", arg0)
 }
 
-// Collect indicates an expected call of Collect.
+// Collect indicates an expected call of Collect
 func (mr *MockInstrumentableCollectorMockRecorder) Collect(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Collect", reflect.TypeOf((*MockInstrumentableCollector)(nil).Collect), arg0)
 }
 
-// CollectWithError mocks base method.
+// CollectWithError mocks base method
 func (m *MockInstrumentableCollector) CollectWithError(arg0 chan<- prometheus.Metric) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CollectWithError", arg0)
@@ -54,25 +53,25 @@ func (m *MockInstrumentableCollector) CollectWithError(arg0 chan<- prometheus.Me
 	return ret0
 }
 
-// CollectWithError indicates an expected call of CollectWithError.
+// CollectWithError indicates an expected call of CollectWithError
 func (mr *MockInstrumentableCollectorMockRecorder) CollectWithError(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CollectWithError", reflect.TypeOf((*MockInstrumentableCollector)(nil).CollectWithError), arg0)
 }
 
-// Describe mocks base method.
+// Describe mocks base method
 func (m *MockInstrumentableCollector) Describe(arg0 chan<- *prometheus.Desc) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Describe", arg0)
 }
 
-// Describe indicates an expected call of Describe.
+// Describe indicates an expected call of Describe
 func (mr *MockInstrumentableCollectorMockRecorder) Describe(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Describe", reflect.TypeOf((*MockInstrumentableCollector)(nil).Describe), arg0)
 }
 
-// GetSubsystem mocks base method.
+// GetSubsystem mocks base method
 func (m *MockInstrumentableCollector) GetSubsystem() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSubsystem")
@@ -80,7 +79,7 @@ func (m *MockInstrumentableCollector) GetSubsystem() string {
 	return ret0
 }
 
-// GetSubsystem indicates an expected call of GetSubsystem.
+// GetSubsystem indicates an expected call of GetSubsystem
 func (mr *MockInstrumentableCollectorMockRecorder) GetSubsystem() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubsystem", reflect.TypeOf((*MockInstrumentableCollector)(nil).GetSubsystem))

--- a/test/pacemaker.metrics
+++ b/test/pacemaker.metrics
@@ -103,6 +103,11 @@ ha_cluster_pacemaker_resources{agent="ocf::heartbeat:Filesystem",clone="c-cluste
 ha_cluster_pacemaker_resources{agent="ocf::heartbeat:Filesystem",clone="c-clusterfs",group="",managed="true",node="node02",resource="clusterfs",role="started",status="failed"} 0
 ha_cluster_pacemaker_resources{agent="ocf::heartbeat:Filesystem",clone="c-clusterfs",group="",managed="true",node="node02",resource="clusterfs",role="started",status="failure_ignored"} 0
 ha_cluster_pacemaker_resources{agent="ocf::heartbeat:Filesystem",clone="c-clusterfs",group="",managed="true",node="node02",resource="clusterfs",role="started",status="orphaned"} 0
+ha_cluster_pacemaker_resources{agent="ocf::heartbeat:Filesystem",clone="c-clusterfs",group="",managed="true",node="",resource="clusterfs",role="stopped",status="active"} 0
+ha_cluster_pacemaker_resources{agent="ocf::heartbeat:Filesystem",clone="c-clusterfs",group="",managed="true",node="",resource="clusterfs",role="stopped",status="blocked"} 0
+ha_cluster_pacemaker_resources{agent="ocf::heartbeat:Filesystem",clone="c-clusterfs",group="",managed="true",node="",resource="clusterfs",role="stopped",status="failed"} 0
+ha_cluster_pacemaker_resources{agent="ocf::heartbeat:Filesystem",clone="c-clusterfs",group="",managed="true",node="",resource="clusterfs",role="stopped",status="failure_ignored"} 0
+ha_cluster_pacemaker_resources{agent="ocf::heartbeat:Filesystem",clone="c-clusterfs",group="",managed="true",node="",resource="clusterfs",role="stopped",status="orphaned"} 0
 ha_cluster_pacemaker_resources{agent="ocf::heartbeat:IPaddr2",clone="",group="",managed="true",node="node01",resource="rsc_ip_PRD_HDB00",role="started",status="active"} 1
 ha_cluster_pacemaker_resources{agent="ocf::heartbeat:IPaddr2",clone="",group="",managed="true",node="node01",resource="rsc_ip_PRD_HDB00",role="started",status="blocked"} 0
 ha_cluster_pacemaker_resources{agent="ocf::heartbeat:IPaddr2",clone="",group="",managed="true",node="node01",resource="rsc_ip_PRD_HDB00",role="started",status="failed"} 0


### PR DESCRIPTION
follow-up of #191, fixes #193 

This is a more generic solution which keeps the tracking of stopped resources even when they are cloned (#191 was a quick and dirty solution that removed the tracking altogether, and only for the clusterfs RA).

Pacemaker Clone Resources appear multiple times in `crm_mon`; since the main discriminator field is the node, and that's missing when a resource is stopped, the cloned _and_ stopped entries will appear multiple times in the `crm_mon` output, with the exact same fields and values: this is a problem for the Prometheus SDK, which doesn't expect duplicate metrics over the course of a single collection cycle.

Collaterally, this PR also removes the `download` make target, which was a vestigial thing required when using old Go versions.