### PR TITLE
Rename dashboard provider subpackage

### DIFF
--- a/packaging/obs/grafana-ha-cluster-dashboards/grafana-ha-cluster-dashboards.changes
+++ b/packaging/obs/grafana-ha-cluster-dashboards/grafana-ha-cluster-dashboards.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jun  4 10:58:51 UTC 2021 - Stefano Torresi <stefano.torresi@suse.com>
+
+- Rename grafana-sleha-cluster-provider subpackage to grafana-sleha-provider 
+
+-------------------------------------------------------------------
 Mon Nov  9 16:41:51 UTC 2020 - Witek Bedyk <witold.bedyk@suse.com>
 
 - Release 1.1.0

--- a/packaging/obs/grafana-ha-cluster-dashboards/grafana-ha-cluster-dashboards.spec
+++ b/packaging/obs/grafana-ha-cluster-dashboards/grafana-ha-cluster-dashboards.spec
@@ -40,6 +40,8 @@ Summary:        Grafana configuration providers for the SLES HA Extension
 Group:          System/Monitoring
 Recommends:     grafana
 BuildArch:      noarch
+Provides:       grafana-sleha-cluster-provider = %version-%release
+Obsoletes:      grafana-sleha-cluster-provider < %version-%release
 
 %description -n grafana-sleha-provider
 Automated configuration provisioners leveraged by other packages to enable a zero-config installation of Grafana dashboards.


### PR DESCRIPTION
Rename `grafana-sleha-cluster-provider` subpackage to `grafana-sleha-provider`.

See https://build.opensuse.org/request/show/897363