### PR TITLE
Fix localtime parsing for config_last_change metric

### DIFF
--- a/collector/pacemaker/pacemaker.go
+++ b/collector/pacemaker/pacemaker.go
@@ -213,7 +213,7 @@ func (c *pacemakerCollector) recordFailCounts(crmMon crmmon.Root, ch chan<- prom
 }
 
 func (c *pacemakerCollector) recordCibLastChange(crmMon crmmon.Root, ch chan<- prometheus.Metric) error {
-	t, err := time.Parse(time.ANSIC, crmMon.Summary.LastChange.Time)
+	t, err := time.ParseInLocation(time.ANSIC, crmMon.Summary.LastChange.Time, time.Local)
 	if err != nil {
 		return errors.Wrap(err, "could not parse date")
 	}

--- a/test/pacemaker.metrics
+++ b/test/pacemaker.metrics
@@ -1,6 +1,6 @@
 # HELP ha_cluster_pacemaker_config_last_change The timestamp of the last change of the cluster configuration
 # TYPE ha_cluster_pacemaker_config_last_change counter
-ha_cluster_pacemaker_config_last_change 1.571399302e+09
+ha_cluster_pacemaker_config_last_change 1.571392102e+09
 # HELP ha_cluster_pacemaker_fail_count The Fail count number per node and resource id
 # TYPE ha_cluster_pacemaker_fail_count gauge
 ha_cluster_pacemaker_fail_count{node="node01",resource="rsc_SAPHanaTopology_PRD_HDB00"} 0


### PR DESCRIPTION
The config_last_change metric was previously generated using time.Parse(time.ANSIC, ...), which interprets timestamps without timezone as UTC. Pacemaker outputs timestamps in localtime, so the resulting Unix epoch was off by the system's UTC offset (e.g., +1h CET).

This change uses time.ParseInLocation with time.Local, ensuring that the localtime from Pacemaker is correctly converted to UTC. This fix is portable across all systems and handles DST automatically.

Metrics will now be accurate in Prometheus and displayed correctly in Grafana dashboards.