### PR TITLE
Upgrade to use go 1.25

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 14

--- a/.github/workflows/exporter-ci.yml
+++ b/.github/workflows/exporter-ci.yml
@@ -53,9 +53,9 @@ jobs:
   obs-commit:
     needs: build
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/trento-project/continuous-delivery:0.1.x
+      image: ghcr.io/trento-project/continuous-delivery@sha256:27b18643b1d39af6551cc165e79fc147835cbb7a5dcef37e6a889f94cea1fef5 # v1.4.0
       options: -u 0:0
       env:
         OBS_USER: ${{ secrets.OBS_USER }}
@@ -75,9 +75,9 @@ jobs:
   obs-submit-request:
     needs: build
     if: github.event.release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/trento-project/continuous-delivery:0.1.x
+      image: ghcr.io/trento-project/continuous-delivery@sha256:27b18643b1d39af6551cc165e79fc147835cbb7a5dcef37e6a889f94cea1fef5 # v1.4.0
       options: -u 0:0
       env:
         OBS_USER: ${{ secrets.OBS_USER }}

--- a/packaging/obs/prometheus-ha_cluster_exporter/prometheus-ha_cluster_exporter.spec
+++ b/packaging/obs/prometheus-ha_cluster_exporter/prometheus-ha_cluster_exporter.spec
@@ -25,7 +25,7 @@ Group:          System/Monitoring
 URL:            https://github.com/ClusterLabs/ha_cluster_exporter
 Source:         %{name}-%{version}.tar.gz
 Source1:        vendor.tar.gz
-BuildRequires:  golang(API) >= 1.23
+BuildRequires:  golang(API) >= 1.25
 Requires(post): %fillup_prereq
 Provides:       ha_cluster_exporter = %{version}-%{release}
 Provides:       prometheus(ha_cluster_exporter) = %{version}-%{release}


### PR DESCRIPTION
Upgrade package to use go 1.25 in the `rpm` built process